### PR TITLE
Parsing of `BioSeq` from Entrez XML

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "ncbi"
 authors = ["Josué D. Figueroa"]
 description = "Rust data structures for NCBI APIs"
 repository = "https://github.com/PoorRican/ncbi-rs/"
-keywords = ["bioinformatics", "ncbi", "dna", "biology", "parser"]
+keywords = ["bioinformatics", "ncbi", "dna", "computational biology", "parser"]
 categories = ["science", "data-structures", "database", "parser-implementations"]
 license = "GPL-3.0-only"
 
-version = "0.1.0-beta"
+version = "0.2.0-beta"
 edition = "2021"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_repr = "0.1.12"
 quick-xml = { version = "0.29.0", features = ["serialize"]}
 atoi = "2.0.0"
+enum_primitive = "0.1.1"
+num = "0.4.0"
 reqwest = { version = "0.11.18", features = ["blocking"] }
 
 # standard crate data is left out

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -2,9 +2,7 @@
 //! Adapted from ["biblio.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/biblio/biblio.asn)
 
 use crate::general::{Date, DbTag, PersonId};
-use crate::parsing_utils::{
-    parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node, read_node, read_string,
-};
+use crate::parsing_utils::{check_unimplemented, read_vec_node, read_node, read_string};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
@@ -342,8 +340,13 @@ impl XmlNode for CitSub {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_node_to(&name, &authors_element, &mut cit.authors, reader);
-                    parse_node_to_option(&name, &date_element, &mut cit.date, reader);
+                    if name == authors_element.name() {
+                        cit.authors = read_node(reader).unwrap();
+                    } else if name == date_element.name() {
+                        cit.date = read_node(reader);
+                    } else {
+                        check_unimplemented(&name, &[]);
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -407,9 +410,15 @@ impl XmlNode for CitGen {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_string_to(&name, &cit_element, &mut gen.cit, reader);
-                    parse_string_to(&name, &title_element, &mut gen.title, reader);
-                    parse_node_to_option(&name, &authors_element, &mut gen.authors, reader);
+                    if name == cit_element.name() {
+                        gen.cit = read_string(reader);
+                    } else if name == title_element.name() {
+                        gen.title = read_string(reader);
+                    } else if name == authors_element.name() {
+                        gen.authors = read_node(reader);
+                    } else {
+                        check_unimplemented(&name, &[])
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -463,7 +472,9 @@ impl XmlNode for AuthListNames {
                     let name = e.name();
 
                     if name == std_element.name() {
-                        return Self::Std(parse_vec_node(reader, std_element.to_end())).into();
+                        return Self::Std(read_vec_node(reader, std_element.to_end())).into();
+                    } else {
+                        check_unimplemented(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -505,8 +516,13 @@ impl XmlNode for AuthList {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_node_to(&name, &names_element, &mut list.names, reader);
-                    parse_node_to_option(&name, &affil_element, &mut list.affil, reader);
+                    if name == names_element.name() {
+                        list.names = read_node(reader).unwrap();
+                    } else if name == affil_element.name() {
+                        list.affil = read_node(reader);
+                    } else {
+                        check_unimplemented(&name, &[]);
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -589,7 +605,11 @@ impl XmlNode for Author {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_node_to(&name, &name_element, &mut author.name, reader);
+                    if name == name_element.name() {
+                        author.name = read_node(reader).unwrap();
+                    } else {
+                        check_unimplemented(&name, &[]);
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -656,13 +676,23 @@ impl XmlNode for AffilStd {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_string_to(&name, &affil_element, &mut affil.affil, reader);
-                    parse_string_to(&name, &div_element, &mut affil.div, reader);
-                    parse_string_to(&name, &city_element, &mut affil.city, reader);
-                    parse_string_to(&name, &sub_element, &mut affil.sub, reader);
-                    parse_string_to(&name, &country_element, &mut affil.country, reader);
-                    parse_string_to(&name, &street_element, &mut affil.street, reader);
-                    parse_string_to(&name, &postal_code_element, &mut affil.postal_code, reader);
+                    if name == affil_element.name() {
+                        affil.affil = read_string(reader);
+                    } else if name == div_element.name() {
+                        affil.div = read_string(reader);
+                    } else if name == city_element.name() {
+                        affil.city = read_string(reader);
+                    } else if name == sub_element.name() {
+                        affil.sub = read_string(reader);
+                    } else if name == country_element.name() {
+                        affil.country = read_string(reader);
+                    } else if name == street_element.name() {
+                        affil.street = read_string(reader);
+                    } else if name == postal_code_element.name() {
+                        affil.postal_code = read_string(reader);
+                    } else {
+                        check_unimplemented(&name, &[]);
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -1,16 +1,18 @@
 //! Bibliographic data elements
 //! Adapted from ["biblio.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/biblio/biblio.asn)
 
+use crate::general::{Date, DbTag, PersonId};
+use crate::parsing_utils::{
+    parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node, read_node, read_string,
+};
+use crate::{XMLElement, XMLElementVec};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use crate::general::{Date, DbTag, PersonId};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{parse_string_to, parse_node_to, parse_node_to_option, read_node, parse_vec_node, read_string};
-use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// represents multiple ways to id an article
 pub enum ArticleId {
     PubMed(PubMedId),
@@ -105,7 +107,7 @@ pub struct PubStatusDate {
 pub type PubStatusDateSet = Vec<PubStatusDate>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// journal or book
 pub enum CitArtFrom {
     Journal(CitJour),
@@ -161,7 +163,7 @@ pub struct CitProc {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Patent citation
 pub struct CitPat {
     pub title: String,
@@ -199,7 +201,7 @@ pub struct CitPat {
     /// priorities
     pub priority: Option<Vec<PatentPriority>>,
 
-    #[serde(rename="abstract")]
+    #[serde(rename = "abstract")]
     /// abstract of patent
     pub r#abstract: Option<String>,
 }
@@ -217,7 +219,7 @@ pub struct PatentPriority {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum IdPatChoice {
     /// patent document number
     Number(String),
@@ -227,7 +229,7 @@ pub enum IdPatChoice {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// identifies a patent
 pub struct IdPat {
     /// patent document country
@@ -252,7 +254,7 @@ pub enum CitLetType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// cite a letter, thesis, or manuscript
 pub struct CitLet {
     /// same fields as a book
@@ -261,7 +263,7 @@ pub struct CitLet {
     /// manuscript identifier
     pub man_id: Option<String>,
 
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: CitLetType,
 }
 
@@ -323,15 +325,17 @@ impl XMLElement for CitSub {
         BytesStart::new("Cit-sub")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let authors_element = BytesStart::new("Cit-sub_authors");
         let date_element = BytesStart::new("Cit-sub_date");
 
-        let mut cit = CitSub::new(
-            AuthList {
-                names: AuthListNames::Std(vec![]), affil: None
-            }
-        );
+        let mut cit = CitSub::new(AuthList {
+            names: AuthListNames::Std(vec![]),
+            affil: None,
+        });
 
         loop {
             match reader.read_event().unwrap() {
@@ -346,7 +350,7 @@ impl XMLElement for CitSub {
                         break;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
 
@@ -355,7 +359,7 @@ impl XMLElement for CitSub {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// NOT from ANSI, this is a catchall
 pub struct CitGen {
     /// anything, not parsable
@@ -387,7 +391,10 @@ impl XMLElement for CitGen {
         BytesStart::new("Cit-gen")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut gen = CitGen::default();
 
         // elements
@@ -409,14 +416,14 @@ impl XMLElement for CitGen {
                         return gen.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum AuthListNames {
     /// full citations
     Std(Vec<Author>),
@@ -443,7 +450,10 @@ impl XMLElement for AuthListNames {
         BytesStart::new("Auth-list_names")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let std_element = BytesStart::new("Auth-list_names_std");
 
@@ -453,15 +463,15 @@ impl XMLElement for AuthListNames {
                     let name = e.name();
 
                     if name == std_element.name() {
-                        return Self::Std(parse_vec_node(reader, std_element.to_end())).into()
+                        return Self::Std(parse_vec_node(reader, std_element.to_end())).into();
                     }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -481,7 +491,10 @@ impl XMLElement for AuthList {
         BytesStart::new("Auth-list")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut list = AuthList::default();
 
         let names_element = BytesStart::new("Auth-list_names");
@@ -497,10 +510,10 @@ impl XMLElement for AuthList {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return list.into()
+                        return list.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -531,7 +544,7 @@ pub enum AuthorRole {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct Author {
     /// author, primary, or secondary
     pub name: PersonId,
@@ -553,7 +566,7 @@ impl Author {
             level: None,
             role: None,
             affil: None,
-            is_corr: None
+            is_corr: None,
         }
     }
 }
@@ -563,7 +576,10 @@ impl XMLElement for Author {
         BytesStart::new("Author")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut author = Author::new(PersonId::default());
 
         let name_element = BytesStart::new("Author_name");
@@ -577,10 +593,10 @@ impl XMLElement for Author {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return author.into()
+                        return author.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -588,7 +604,7 @@ impl XMLElement for Author {
 impl XMLElementVec for Author {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// std representation for affiliations
 pub struct AffilStd {
     /// Author Affiliation, Name
@@ -620,7 +636,10 @@ impl XMLElement for AffilStd {
         BytesStart::new("Affil_std")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut affil = AffilStd::default();
 
         // elements
@@ -647,17 +666,17 @@ impl XMLElement for AffilStd {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return affil.into()
+                        return affil.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum Affil {
     /// unparsed string
     Str(String),
@@ -671,7 +690,10 @@ impl XMLElement for Affil {
         BytesStart::new("Affil")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let str_element = BytesStart::new("Affil_str");
         let std_element = BytesStart::new("Affil_std");
@@ -682,25 +704,25 @@ impl XMLElement for Affil {
                     let name = e.name();
 
                     if name == std_element.name() {
-                        return Self::Std(read_node(reader).unwrap()).into()
+                        return Self::Std(read_node(reader).unwrap()).into();
                     }
                     if name == str_element.name() {
-                        return Self::Str(read_string(reader).unwrap()).into()
+                        return Self::Str(read_string(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// title group
 ///
 /// # Variants
@@ -726,7 +748,7 @@ pub enum TitleItem {
     /// Valid:  J
     Jta(String),
 
-    #[serde(rename="iso-jta")]
+    #[serde(rename = "iso-jta")]
     /// Title, MEDLINE jta
     /// Valid:  J
     IsoJta(String),
@@ -773,7 +795,7 @@ pub enum ImprintPrePub {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct Imprint {
     /// date of publication
     pub date: Date,
@@ -783,7 +805,7 @@ pub struct Imprint {
     pub pages: Option<String>,
     pub section: Option<String>,
 
-    #[serde(rename="pub")]
+    #[serde(rename = "pub")]
     /// publisher, required for book
     pub r#pub: Option<Affil>,
 
@@ -837,7 +859,7 @@ pub enum CitRetractType {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct CitRetract {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     /// retraction of an entry
     pub r#type: CitRetractType,
 

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -7,7 +7,7 @@ use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::parsing_utils::{try_next_string, parse_next_string_into};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -601,6 +601,7 @@ impl XMLElement for Author {
         }
     }
 }
+impl XMLElementVec for Author {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(rename_all="kebab-case")]

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -301,7 +301,7 @@ pub struct CitSub {
     pub descr: Option<String>,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(rename_all="kebab-case")]
 /// NOT from ANSI, this is a catchall
 pub struct CitGen {
@@ -389,6 +389,18 @@ pub struct Author {
 
     /// true if [corresponding author](https://scientific-publishing.webshop.elsevier.com/publication-recognition/what-corresponding-author/)
     pub is_corr: Option<bool>,
+}
+
+impl Author {
+    pub fn new(name: PersonId) -> Self {
+        Self {
+            name,
+            level: None,
+            role: None,
+            affil: None,
+            is_corr: None
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -344,7 +344,7 @@ impl XmlNode for CitSub {
                         cit.authors = read_node(reader).unwrap();
                     } else if name == date_element.name() {
                         cit.date = read_node(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -416,7 +416,7 @@ impl XmlNode for CitGen {
                         gen.title = read_string(reader);
                     } else if name == authors_element.name() {
                         gen.authors = read_node(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[])
                     }
                 }
@@ -473,7 +473,7 @@ impl XmlNode for AuthListNames {
 
                     if name == std_element.name() {
                         return Self::Std(read_vec_node(reader, std_element.to_end())).into();
-                    } else {
+                    } else if name == Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -520,7 +520,7 @@ impl XmlNode for AuthList {
                         list.names = read_node(reader).unwrap();
                     } else if name == affil_element.name() {
                         list.affil = read_node(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -690,7 +690,7 @@ impl XmlNode for AffilStd {
                         affil.street = read_string(reader);
                     } else if name == postal_code_element.name() {
                         affil.postal_code = read_string(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -5,7 +5,7 @@ use crate::general::{Date, DbTag, PersonId};
 use crate::parsing_utils::{
     parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node, read_node, read_string,
 };
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
@@ -320,7 +320,7 @@ impl CitSub {
     }
 }
 
-impl XMLElement for CitSub {
+impl XmlNode for CitSub {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Cit-sub")
     }
@@ -386,7 +386,7 @@ pub struct CitGen {
     pub pmid: Option<PubMedId>,
 }
 
-impl XMLElement for CitGen {
+impl XmlNode for CitGen {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Cit-gen")
     }
@@ -445,7 +445,7 @@ impl Default for AuthListNames {
     }
 }
 
-impl XMLElement for AuthListNames {
+impl XmlNode for AuthListNames {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Auth-list_names")
     }
@@ -486,7 +486,7 @@ pub struct AuthList {
     pub affil: Option<Affil>,
 }
 
-impl XMLElement for AuthList {
+impl XmlNode for AuthList {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Auth-list")
     }
@@ -571,7 +571,7 @@ impl Author {
     }
 }
 
-impl XMLElement for Author {
+impl XmlNode for Author {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Author")
     }
@@ -601,7 +601,7 @@ impl XMLElement for Author {
         }
     }
 }
-impl XMLElementVec for Author {}
+impl XmlVecNode for Author {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -631,7 +631,7 @@ pub struct AffilStd {
     pub postal_code: Option<String>,
 }
 
-impl XMLElement for AffilStd {
+impl XmlNode for AffilStd {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Affil_std")
     }
@@ -685,7 +685,7 @@ pub enum Affil {
     Std(AffilStd),
 }
 
-impl XMLElement for Affil {
+impl XmlNode for Affil {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Affil")
     }

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -6,7 +6,7 @@ use quick_xml::Reader;
 use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{try_next_string, parse_next_string_to};
+use crate::parsing_utils::{next_string, parse_next_string_to, try_node_to, try_node_to_option};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -338,12 +338,8 @@ impl XMLElement for CitSub {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    if name == authors_element.name() {
-                        cit.authors = AuthList::from_reader(reader).unwrap();
-                    }
-                    if name == date_element.name() {
-                        cit.date = Date::from_reader(reader);
-                    }
+                    try_node_to(&name, &authors_element, &mut cit.authors, reader);
+                    try_node_to_option(&name, &authors_element, &mut cit.date, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -404,15 +400,9 @@ impl XMLElement for CitGen {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    if name == cit_element.name() {
-                        gen.cit = try_next_string(reader);
-                    }
-                    else if name == authors_element.name() {
-                        gen.authors = AuthList::from_reader(reader);
-                    }
-                    else if name == title_element.name() {
-                        gen.title = try_next_string(reader)
-                    }
+                    parse_next_string_to(&name, &cit_element, &mut gen.cit, reader);
+                    parse_next_string_to(&name, &title_element, &mut gen.title, reader);
+                    try_node_to_option(&name, &authors_element, &mut gen.authors, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -502,12 +492,8 @@ impl XMLElement for AuthList {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    if name == names_element.name() {
-                        list.names = AuthListNames::from_reader(reader).unwrap();
-                    }
-                    else if name == affil_element.name() {
-                        list.affil = Affil::from_reader(reader)
-                    }
+                    try_node_to(&name, &names_element, &mut list.names, reader);
+                    try_node_to_option(&name, &affil_element, &mut list.affil, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -587,9 +573,7 @@ impl XMLElement for Author {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    if name == name_element.name() {
-                        author.name = PersonId::from_reader(reader).unwrap();
-                    }
+                    try_node_to(&name, &name_element, &mut author.name, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -2,7 +2,7 @@
 //! Adapted from ["biblio.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/biblio/biblio.asn)
 
 use crate::general::{Date, DbTag, PersonId};
-use crate::parsing::{check_unexpected, read_vec_node, read_node, read_string};
+use crate::parsing::{read_vec_node, read_node, read_string, UnexpectedTags};
 use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
@@ -335,6 +335,8 @@ impl XmlNode for CitSub {
             affil: None,
         });
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -345,7 +347,7 @@ impl XmlNode for CitSub {
                     } else if name == date_element.name() {
                         cit.date = read_node(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -405,6 +407,8 @@ impl XmlNode for CitGen {
         let authors_element = BytesStart::new("Cit-gen_authors");
         let title_element = BytesStart::new("Cit-gen_title");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -417,7 +421,7 @@ impl XmlNode for CitGen {
                     } else if name == authors_element.name() {
                         gen.authors = read_node(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[])
+                        forbidden.check(&name)
                     }
                 }
                 Event::End(e) => {
@@ -466,6 +470,8 @@ impl XmlNode for AuthListNames {
         // variants
         let std_element = BytesStart::new("Auth-list_names_std");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -474,7 +480,7 @@ impl XmlNode for AuthListNames {
                     if name == std_element.name() {
                         return Self::Std(read_vec_node(reader, std_element.to_end())).into();
                     } else if name == Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -511,6 +517,8 @@ impl XmlNode for AuthList {
         let names_element = BytesStart::new("Auth-list_names");
         let affil_element = BytesStart::new("Auth-list_affil");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -521,7 +529,7 @@ impl XmlNode for AuthList {
                     } else if name == affil_element.name() {
                         list.affil = read_node(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -600,6 +608,8 @@ impl XmlNode for Author {
 
         let name_element = BytesStart::new("Author_name");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -608,7 +618,7 @@ impl XmlNode for Author {
                     if name == name_element.name() {
                         author.name = read_node(reader).unwrap();
                     } else {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -671,6 +681,8 @@ impl XmlNode for AffilStd {
         let street_element = BytesStart::new("Affil_std_street");
         let postal_code_element = BytesStart::new("Affil_std_postal-code");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -691,7 +703,7 @@ impl XmlNode for AffilStd {
                     } else if name == postal_code_element.name() {
                         affil.postal_code = read_string(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -2,8 +2,8 @@
 //! Adapted from ["biblio.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/biblio/biblio.asn)
 
 use crate::general::{Date, DbTag, PersonId};
-use crate::parsing_utils::{check_unexpected, read_vec_node, read_node, read_string};
-use crate::{XmlNode, XmlVecNode};
+use crate::parsing::{check_unexpected, read_vec_node, read_node, read_string};
+use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -6,7 +6,7 @@ use quick_xml::Reader;
 use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{try_next_string, parse_next_string_into};
+use crate::parsing_utils::{try_next_string, parse_next_string_to};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -653,13 +653,13 @@ impl XMLElement for AffilStd {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_next_string_into(&name, &affil_element, &mut affil.affil, reader);
-                    parse_next_string_into(&name, &div_element, &mut affil.div, reader);
-                    parse_next_string_into(&name, &city_element, &mut affil.city, reader);
-                    parse_next_string_into(&name, &sub_element, &mut affil.sub, reader);
-                    parse_next_string_into(&name, &country_element, &mut affil.country, reader);
-                    parse_next_string_into(&name, &street_element, &mut affil.street, reader);
-                    parse_next_string_into(&name, &postal_code_element, &mut affil.postal_code, reader);
+                    parse_next_string_to(&name, &affil_element, &mut affil.affil, reader);
+                    parse_next_string_to(&name, &div_element, &mut affil.div, reader);
+                    parse_next_string_to(&name, &city_element, &mut affil.city, reader);
+                    parse_next_string_to(&name, &sub_element, &mut affil.sub, reader);
+                    parse_next_string_to(&name, &country_element, &mut affil.country, reader);
+                    parse_next_string_to(&name, &street_element, &mut affil.street, reader);
+                    parse_next_string_to(&name, &postal_code_element, &mut affil.postal_code, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -6,7 +6,7 @@ use quick_xml::Reader;
 use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{read_string, parse_next_string_to, parse_node_to, parse_node_to_option};
+use crate::parsing_utils::{parse_string_to, parse_node_to, parse_node_to_option, read_node, parse_vec_node, read_string};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -339,7 +339,7 @@ impl XMLElement for CitSub {
                     let name = e.name();
 
                     parse_node_to(&name, &authors_element, &mut cit.authors, reader);
-                    parse_node_to_option(&name, &authors_element, &mut cit.date, reader);
+                    parse_node_to_option(&name, &date_element, &mut cit.date, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -400,8 +400,8 @@ impl XMLElement for CitGen {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_next_string_to(&name, &cit_element, &mut gen.cit, reader);
-                    parse_next_string_to(&name, &title_element, &mut gen.title, reader);
+                    parse_string_to(&name, &cit_element, &mut gen.cit, reader);
+                    parse_string_to(&name, &title_element, &mut gen.title, reader);
                     parse_node_to_option(&name, &authors_element, &mut gen.authors, reader);
                 }
                 Event::End(e) => {
@@ -453,7 +453,7 @@ impl XMLElement for AuthListNames {
                     let name = e.name();
 
                     if name == std_element.name() {
-                        return Self::Std(Author::vec_from_reader(reader, Self::start_bytes().to_end())).into()
+                        return Self::Std(parse_vec_node(reader, std_element.to_end())).into()
                     }
                 }
                 Event::End(e) => {
@@ -637,13 +637,13 @@ impl XMLElement for AffilStd {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_next_string_to(&name, &affil_element, &mut affil.affil, reader);
-                    parse_next_string_to(&name, &div_element, &mut affil.div, reader);
-                    parse_next_string_to(&name, &city_element, &mut affil.city, reader);
-                    parse_next_string_to(&name, &sub_element, &mut affil.sub, reader);
-                    parse_next_string_to(&name, &country_element, &mut affil.country, reader);
-                    parse_next_string_to(&name, &street_element, &mut affil.street, reader);
-                    parse_next_string_to(&name, &postal_code_element, &mut affil.postal_code, reader);
+                    parse_string_to(&name, &affil_element, &mut affil.affil, reader);
+                    parse_string_to(&name, &div_element, &mut affil.div, reader);
+                    parse_string_to(&name, &city_element, &mut affil.city, reader);
+                    parse_string_to(&name, &sub_element, &mut affil.sub, reader);
+                    parse_string_to(&name, &country_element, &mut affil.country, reader);
+                    parse_string_to(&name, &street_element, &mut affil.street, reader);
+                    parse_string_to(&name, &postal_code_element, &mut affil.postal_code, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -682,7 +682,10 @@ impl XMLElement for Affil {
                     let name = e.name();
 
                     if name == std_element.name() {
-                        return Self::Std(AffilStd::from_reader(reader).unwrap()).into()
+                        return Self::Std(read_node(reader).unwrap()).into()
+                    }
+                    if name == str_element.name() {
+                        return Self::Str(read_string(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -6,7 +6,7 @@ use quick_xml::Reader;
 use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{get_next_text, try_field};
+use crate::parsing_utils::{try_next_string, parse_next_string_into};
 use crate::XMLElement;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -405,13 +405,13 @@ impl XMLElement for CitGen {
                     let name = e.name();
 
                     if name == cit_element.name() {
-                        gen.cit = get_next_text(reader);
+                        gen.cit = try_next_string(reader);
                     }
                     else if name == authors_element.name() {
                         gen.authors = AuthList::from_reader(reader);
                     }
                     else if name == title_element.name() {
-                        gen.title = get_next_text(reader)
+                        gen.title = try_next_string(reader)
                     }
                 }
                 Event::End(e) => {
@@ -652,13 +652,13 @@ impl XMLElement for AffilStd {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_field(&name, &affil_element, &mut affil.affil, reader);
-                    try_field(&name, &div_element, &mut affil.div, reader);
-                    try_field(&name, &city_element, &mut affil.city, reader);
-                    try_field(&name, &sub_element, &mut affil.sub, reader);
-                    try_field(&name, &country_element, &mut affil.country, reader);
-                    try_field(&name, &street_element, &mut affil.street, reader);
-                    try_field(&name, &postal_code_element, &mut affil.postal_code, reader);
+                    parse_next_string_into(&name, &affil_element, &mut affil.affil, reader);
+                    parse_next_string_into(&name, &div_element, &mut affil.div, reader);
+                    parse_next_string_into(&name, &city_element, &mut affil.city, reader);
+                    parse_next_string_into(&name, &sub_element, &mut affil.sub, reader);
+                    parse_next_string_into(&name, &country_element, &mut affil.country, reader);
+                    parse_next_string_into(&name, &street_element, &mut affil.street, reader);
+                    parse_next_string_into(&name, &postal_code_element, &mut affil.postal_code, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -2,7 +2,7 @@
 //! Adapted from ["biblio.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/biblio/biblio.asn)
 
 use crate::general::{Date, DbTag, PersonId};
-use crate::parsing_utils::{check_unimplemented, read_vec_node, read_node, read_string};
+use crate::parsing_utils::{check_unexpected, read_vec_node, read_node, read_string};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
@@ -345,7 +345,7 @@ impl XmlNode for CitSub {
                     } else if name == date_element.name() {
                         cit.date = read_node(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -417,7 +417,7 @@ impl XmlNode for CitGen {
                     } else if name == authors_element.name() {
                         gen.authors = read_node(reader);
                     } else {
-                        check_unimplemented(&name, &[])
+                        check_unexpected(&name, &[])
                     }
                 }
                 Event::End(e) => {
@@ -474,7 +474,7 @@ impl XmlNode for AuthListNames {
                     if name == std_element.name() {
                         return Self::Std(read_vec_node(reader, std_element.to_end())).into();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -521,7 +521,7 @@ impl XmlNode for AuthList {
                     } else if name == affil_element.name() {
                         list.affil = read_node(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -608,7 +608,7 @@ impl XmlNode for Author {
                     if name == name_element.name() {
                         author.name = read_node(reader).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -691,7 +691,7 @@ impl XmlNode for AffilStd {
                     } else if name == postal_code_element.name() {
                         affil.postal_code = read_string(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -6,7 +6,7 @@ use quick_xml::Reader;
 use crate::general::{Date, DbTag, PersonId};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{next_string, parse_next_string_to, try_node_to, try_node_to_option};
+use crate::parsing_utils::{read_string, parse_next_string_to, parse_node_to, parse_node_to_option};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -338,8 +338,8 @@ impl XMLElement for CitSub {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_node_to(&name, &authors_element, &mut cit.authors, reader);
-                    try_node_to_option(&name, &authors_element, &mut cit.date, reader);
+                    parse_node_to(&name, &authors_element, &mut cit.authors, reader);
+                    parse_node_to_option(&name, &authors_element, &mut cit.date, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -402,7 +402,7 @@ impl XMLElement for CitGen {
 
                     parse_next_string_to(&name, &cit_element, &mut gen.cit, reader);
                     parse_next_string_to(&name, &title_element, &mut gen.title, reader);
-                    try_node_to_option(&name, &authors_element, &mut gen.authors, reader);
+                    parse_node_to_option(&name, &authors_element, &mut gen.authors, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -492,8 +492,8 @@ impl XMLElement for AuthList {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_node_to(&name, &names_element, &mut list.names, reader);
-                    try_node_to_option(&name, &affil_element, &mut list.affil, reader);
+                    parse_node_to(&name, &names_element, &mut list.names, reader);
+                    parse_node_to_option(&name, &affil_element, &mut list.affil, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -573,7 +573,7 @@ impl XMLElement for Author {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_node_to(&name, &name_element, &mut author.name, reader);
+                    parse_node_to(&name, &name_element, &mut author.name, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -62,7 +62,7 @@ impl XMLElement for ObjectId {
         BytesStart::new("Object-id")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         // variants
         let id_element = BytesStart::new("Object-id_id");
         let str_element = BytesStart::new("Object-id_str");
@@ -78,7 +78,7 @@ impl XMLElement for ObjectId {
                 }
                 else if e.name() == str_element.name() {
                     if let Event::Text(text) = reader.read_event().unwrap() {
-                        return ObjectId::Str(text.escape_ascii().to_string())
+                        return ObjectId::Str(text.escape_ascii().to_string()).into()
                     }
                 }
             }
@@ -99,7 +99,7 @@ impl XMLElement for DbTag {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Dbtag")
     }
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         let mut db = None;
         let mut tag = None;
 
@@ -115,7 +115,7 @@ impl XMLElement for DbTag {
                         }
                     }
                     else if e.name() == tag_element.name() {
-                        tag = ObjectId::from_reader(reader).into();
+                        tag = ObjectId::from_reader(reader);
                     }
                 }
                 Event::End(e) => {
@@ -130,7 +130,7 @@ impl XMLElement for DbTag {
         Self {
             db: db.unwrap(),
             tag: tag.unwrap(),
-        }
+        }.into()
     }
 }
 

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -409,14 +409,14 @@ impl XmlVecNode for UserObject {}
 pub enum UserData {
     Str(String),
     Int(i64),
-    Real(f64),
+    Real(String),
     Bool(bool),
     // OS(`octal string`),
     /// for using other definitions
     Object(UserObject),
     Strs(Vec<String>),
     Ints(Vec<i64>),
-    Reals(Vec<f64>),
+    Reals(Vec<String>),
     Fields(Vec<UserField>),
     Objects(Vec<UserObject>),
 }

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -2,7 +2,7 @@
 //!
 //! As per [general.asn](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/asn_spec/general.asn.html)
 
-use crate::parsing::{check_unexpected, read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
+use crate::parsing::{read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked, UnexpectedTags};
 use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
@@ -96,6 +96,8 @@ impl XmlNode for DateStd {
         let month_element = BytesStart::new("Date-std_month");
         let day_element = BytesStart::new("Date-std_day");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -108,7 +110,7 @@ impl XmlNode for DateStd {
                     } else if name == day_element.name() {
                         date.day = read_int(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -291,6 +293,8 @@ impl XmlNode for NameStd {
         let first_element = BytesStart::new("Name-std_first");
         let initials_element = BytesStart::new("Name-std_initials");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -303,7 +307,7 @@ impl XmlNode for NameStd {
                     } else if name == initials_element.name() {
                         name_std.initials = read_string(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -465,6 +469,8 @@ impl XmlNode for UserData {
         let fields_element = BytesStart::new("User-field_data_fields");
         let objects_element = BytesStart::new("User-field_data_objects");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -493,7 +499,7 @@ impl XmlNode for UserData {
                     } else if name == objects_element.name() {
                         return Self::Objects(read_vec_node(reader, objects_element.to_end())).into()
                     } else if name != BytesStart::new("User-field_label").name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 _ => (),
@@ -528,6 +534,8 @@ impl XmlNode for UserField {
         let num_element = BytesStart::new("User-field_num");
         let data_element = BytesStart::new("User-field_data");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -540,7 +548,7 @@ impl XmlNode for UserField {
                     } else if name == num_element.name() {
                         field.num = read_int(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[])
+                        forbidden.check(&name)
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -7,7 +7,7 @@ use crate::parsing_utils::{
     parse_vec_node_to, read_int, read_node, read_string, read_vec_int_unchecked,
     read_vec_str_unchecked,
 };
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ impl Default for Date {
     }
 }
 
-impl XMLElement for Date {
+impl XmlNode for Date {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Date")
     }
@@ -84,7 +84,7 @@ pub struct DateStd {
     pub second: Option<u8>,
 }
 
-impl XMLElement for DateStd {
+impl XmlNode for DateStd {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Date-std")
     }
@@ -134,7 +134,7 @@ impl Default for ObjectId {
     }
 }
 
-impl XMLElement for ObjectId {
+impl XmlNode for ObjectId {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Object-id")
     }
@@ -166,7 +166,7 @@ pub struct DbTag {
     pub tag: ObjectId,
 }
 
-impl XMLElement for DbTag {
+impl XmlNode for DbTag {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Dbtag")
     }
@@ -194,7 +194,7 @@ impl XMLElement for DbTag {
         }
     }
 }
-impl XMLElementVec for DbTag {}
+impl XmlVecNode for DbTag {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -218,7 +218,7 @@ impl Default for PersonId {
     }
 }
 
-impl XMLElement for PersonId {
+impl XmlNode for PersonId {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Person-id")
     }
@@ -270,7 +270,7 @@ pub struct NameStd {
     pub title: Option<String>,
 }
 
-impl XMLElement for NameStd {
+impl XmlNode for NameStd {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Name-std")
     }
@@ -367,7 +367,7 @@ pub struct UserObject {
     pub data: Vec<UserField>,
 }
 
-impl XMLElement for UserObject {
+impl XmlNode for UserObject {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("User-object")
     }
@@ -402,7 +402,7 @@ impl XMLElement for UserObject {
         }
     }
 }
-impl XMLElementVec for UserObject {}
+impl XmlVecNode for UserObject {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -477,7 +477,7 @@ impl Default for UserData {
     }
 }
 
-impl XMLElement for UserData {
+impl XmlNode for UserData {
     /// This enumerated value is not enclosed by a tag
     fn start_bytes() -> BytesStart<'static> {
         unimplemented!()
@@ -551,7 +551,7 @@ pub struct UserField {
     pub data: UserData,
 }
 
-impl XMLElement for UserField {
+impl XmlNode for UserField {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("User-field")
     }
@@ -586,4 +586,4 @@ impl XMLElement for UserField {
         }
     }
 }
-impl XMLElementVec for UserField {}
+impl XmlVecNode for UserField {}

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -7,7 +7,7 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Serialize, Deserialize};
 use crate::parsing_utils::{try_next_int, try_next_string, get_vec_node, parse_vec_int_unchecked, parse_vec_str_unchecked, parse_next_string_into};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -209,6 +209,7 @@ impl XMLElement for DbTag {
         }.into()
     }
 }
+impl XMLElementVec for DbTag {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -595,3 +596,4 @@ impl XMLElement for UserField {
         }
     }
 }
+impl XMLElementVec for UserField {}

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -448,7 +448,11 @@ impl UserData {
     where
         Self: Sized,
     {
-        unimplemented!()
+        let end = BytesEnd::new("User-field_data_reals");
+
+        let items = read_vec_str_unchecked(reader, &end);
+
+        return Self::Reals(items).into();
     }
 
     fn parse_fields(reader: &mut Reader<&[u8]>) -> Option<Self>
@@ -511,7 +515,7 @@ impl XmlNode for UserData {
                         return Self::Int(read_int::<i64>(reader).unwrap()).into();
                     }
                     if name == real_element.name() {
-                        unimplemented!()
+                        return Self::Real(read_real(reader).unwrap()).into()
                     }
                     if name == bool_element.name() {
                         unimplemented!()

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -2,9 +2,9 @@
 //!
 //! As per [general.asn](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/asn_spec/general.asn.html)
 
-use crate::parsing_utils::{check_unexpected, read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
-use crate::{XmlNode, XmlVecNode};
-use quick_xml::events::{BytesEnd, BytesStart, Event};
+use crate::parsing::{check_unexpected, read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
+use crate::parsing::{XmlNode, XmlVecNode};
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
 
@@ -560,7 +560,7 @@ impl XmlVecNode for UserField {}
 mod tests {
     use quick_xml::Reader;
     use crate::general::UserField;
-    use crate::parsing_utils::read_node;
+    use crate::parsing::read_node;
 
     #[test]
     /// tests a bug where nested <User-field_data_fields> is not denoted by tag

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -2,7 +2,7 @@
 //!
 //! As per [general.asn](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/asn_spec/general.asn.html)
 
-use crate::parsing_utils::{check_unimplemented, read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
+use crate::parsing_utils::{check_unexpected, read_vec_node, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
@@ -108,7 +108,7 @@ impl XmlNode for DateStd {
                     } else if name == day_element.name() {
                         date.day = read_int(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -303,7 +303,7 @@ impl XmlNode for NameStd {
                     } else if name == initials_element.name() {
                         name_std.initials = read_string(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -544,7 +544,7 @@ impl XmlNode for UserData {
                     } else if name == objects_element.name() {
                         return Self::parse_objects(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 _ => (),
@@ -591,7 +591,7 @@ impl XmlNode for UserField {
                     } else if name == num_element.name() {
                         field.num = read_int(reader);
                     } else {
-                        check_unimplemented(&name, &[])
+                        check_unexpected(&name, &[])
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -440,7 +440,7 @@ impl UserData {
         return Self::Ints(items).into();
     }
 
-    fn parse_reals(_reader: &mut Reader<&[u8]>) -> Option<Self>
+    fn parse_reals(reader: &mut Reader<&[u8]>) -> Option<Self>
     where
         Self: Sized,
     {

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -150,7 +150,7 @@ pub enum PersonId {
     Consortium(String),
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 /// structured names
 pub struct NameStd {
     pub last: String,

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -2,11 +2,7 @@
 //!
 //! As per [general.asn](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/asn_spec/general.asn.html)
 
-use crate::parsing_utils::{
-    parse_int_to, parse_int_to_option, parse_node_to, parse_string_to, parse_vec_node,
-    parse_vec_node_to, read_int, read_node, read_string, read_vec_int_unchecked,
-    read_vec_str_unchecked,
-};
+use crate::parsing_utils::{parse_int_to, parse_int_to_option, parse_node_to, parse_string_to, parse_vec_node, parse_vec_node_to, read_int, read_node, read_real, read_string, read_vec_int_unchecked, read_vec_str_unchecked};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;

--- a/src/asn/general.rs
+++ b/src/asn/general.rs
@@ -2,14 +2,18 @@
 //!
 //! As per [general.asn](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/asn_spec/general.asn.html)
 
+use crate::parsing_utils::{
+    parse_int_to, parse_int_to_option, parse_node_to, parse_string_to, parse_vec_node,
+    parse_vec_node_to, read_int, read_node, read_string, read_vec_int_unchecked,
+    read_vec_str_unchecked,
+};
+use crate::{XMLElement, XMLElementVec};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
-use serde::{Serialize, Deserialize};
-use crate::parsing_utils::{read_int, read_string, parse_vec_node, read_vec_int_unchecked, read_vec_str_unchecked, parse_string_to, parse_int_to, parse_int_to_option, parse_node_to, parse_vec_node_to, read_node};
-use crate::{XMLElement, XMLElementVec};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Model precise timestamp or an un-parsed string
 ///
 /// The string form is a fall-back for when the input data cannot be parsed
@@ -22,12 +26,10 @@ pub enum Date {
 
 impl Default for Date {
     fn default() -> Self {
-        Self::Date(
-            DateStd {
-                year: 2023,
-                ..DateStd::default()
-            }
-        )
+        Self::Date(DateStd {
+            year: 2023,
+            ..DateStd::default()
+        })
     }
 }
 
@@ -36,7 +38,10 @@ impl XMLElement for Date {
         BytesStart::new("Date")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let std_element = BytesStart::new("Date-std");
 
@@ -51,10 +56,10 @@ impl XMLElement for Date {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -84,7 +89,10 @@ impl XMLElement for DateStd {
         BytesStart::new("Date-std")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut date = Self::default();
 
         // elements
@@ -103,10 +111,10 @@ impl XMLElement for DateStd {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return date.into()
+                        return date.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -139,10 +147,10 @@ impl XMLElement for ObjectId {
         loop {
             if let Event::Start(e) = reader.read_event().unwrap() {
                 if e.name() == id_element.name() {
-                    return ObjectId::Id(read_int(reader).unwrap()).into()
+                    return ObjectId::Id(read_int(reader).unwrap()).into();
                 }
                 if e.name() == str_element.name() {
-                    return ObjectId::Str(read_string(reader).unwrap()).into()
+                    return ObjectId::Str(read_string(reader).unwrap()).into();
                 }
             }
         }
@@ -178,10 +186,10 @@ impl XMLElement for DbTag {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return tag.into()
+                        return tag.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -189,7 +197,7 @@ impl XMLElement for DbTag {
 impl XMLElementVec for DbTag {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// define a std element for people
 pub enum PersonId {
     /// any defined database tag
@@ -215,7 +223,10 @@ impl XMLElement for PersonId {
         BytesStart::new("Person-id")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let name_element = BytesStart::new("Person-id_name");
 
@@ -225,15 +236,15 @@ impl XMLElement for PersonId {
                     let name = e.name();
 
                     if name == name_element.name() {
-                        return PersonId::Name(read_node(reader).unwrap()).into()
+                        return PersonId::Name(read_node(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -264,7 +275,10 @@ impl XMLElement for NameStd {
         BytesStart::new("Name-std")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut name_std = NameStd::default();
 
         // elements
@@ -283,12 +297,11 @@ impl XMLElement for NameStd {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return name_std.into()
+                        return name_std.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
-
         }
     }
 }
@@ -300,7 +313,7 @@ pub struct Range {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum FuzzLimit {
     /// unknown
     Unk,
@@ -325,10 +338,10 @@ pub enum FuzzLimit {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Communicate uncertainties in integer values
 pub enum IntFuzz {
-    #[serde(rename="p-m")]
+    #[serde(rename = "p-m")]
     /// plus or minus fixed amount
     PM(i64),
 
@@ -346,7 +359,7 @@ pub struct UserObject {
     /// endeavor which designed this object
     pub class: Option<String>,
 
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     /// type of object within class
     pub r#type: ObjectId,
 
@@ -359,7 +372,10 @@ impl XMLElement for UserObject {
         BytesStart::new("User-object")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut object = Self::default();
 
         // elements
@@ -378,10 +394,10 @@ impl XMLElement for UserObject {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return object.into()
+                        return object.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -389,7 +405,7 @@ impl XMLElement for UserObject {
 impl XMLElementVec for UserObject {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum UserData {
     Str(String),
     Int(i64),
@@ -406,41 +422,51 @@ pub enum UserData {
 }
 
 impl UserData {
-    fn parse_strs(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-
+    fn parse_strs(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let end = BytesEnd::new("User-field_data_strs");
 
         let items = read_vec_str_unchecked(reader, &end);
 
-        return Self::Strs(items).into()
+        return Self::Strs(items).into();
     }
 
-    fn parse_ints(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn parse_ints(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let end = BytesEnd::new("User-field_data_ints");
 
         let items = read_vec_int_unchecked(reader, &end);
 
-        return Self::Ints(items).into()
+        return Self::Ints(items).into();
     }
 
-    fn parse_reals(_reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn parse_reals(_reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         unimplemented!()
     }
 
-    fn parse_fields(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn parse_fields(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let end = BytesEnd::new("User-field_data_fields");
 
-        return Self::Fields(
-            parse_vec_node(reader, end)
-        ).into()
+        return Self::Fields(parse_vec_node(reader, end)).into();
     }
 
-    fn parse_objects(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn parse_objects(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let end = BytesEnd::new("User-field_data_fields");
 
-        return Self::Objects(
-            parse_vec_node(reader, end)
-        ).into()
+        return Self::Objects(parse_vec_node(reader, end)).into();
     }
 }
 
@@ -457,7 +483,10 @@ impl XMLElement for UserData {
         unimplemented!()
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let str_element = BytesStart::new("User-field_data_str");
         let int_element = BytesStart::new("User-field_data_int");
@@ -491,22 +520,22 @@ impl XMLElement for UserData {
                         return Self::Object(read_node(reader).unwrap()).into();
                     }
                     if name == strs_element.name() {
-                        return Self::parse_strs(reader)
+                        return Self::parse_strs(reader);
                     }
                     if name == ints_element.name() {
-                        return Self::parse_ints(reader)
+                        return Self::parse_ints(reader);
                     }
                     if name == reals_element.name() {
-                        return Self::parse_reals(reader)
+                        return Self::parse_reals(reader);
                     }
                     if name == fields_element.name() {
-                        return Self::parse_fields(reader)
+                        return Self::parse_fields(reader);
                     }
                     if name == objects_element.name() {
-                        return Self::parse_objects(reader)
+                        return Self::parse_objects(reader);
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -527,7 +556,10 @@ impl XMLElement for UserField {
         BytesStart::new("User-field")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut field = Self::default();
 
         // elements
@@ -546,10 +578,10 @@ impl XMLElement for UserField {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return field.into()
+                        return field.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }

--- a/src/asn/medline.rs
+++ b/src/asn/medline.rs
@@ -4,7 +4,7 @@
 
 use crate::biblio::{CitArt, PubMedId};
 use crate::general::Date;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug, Default)]
@@ -28,7 +28,7 @@ pub enum MedlineEntryStatus {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// a MEDLINE or PubMed entry
 pub struct MedlineEntry {
     /// MEDLINE UID, sometimes not yet available from PubMed
@@ -40,7 +40,7 @@ pub struct MedlineEntry {
     /// article citation
     pub cit: CitArt,
 
-    #[serde(rename="abstract")]
+    #[serde(rename = "abstract")]
     pub r#abstract: Option<String>,
     pub mesh: Option<Vec<MedlineMesh>>,
     pub substance: Option<Vec<MedlineRn>>,
@@ -78,9 +78,8 @@ pub struct MedlineMesh {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct MedlineQual {
-
     /// true if main point
-    pub mp: bool,           // TODO: default false
+    pub mp: bool, // TODO: default false
 
     /// the subheading
     pub subh: String,
@@ -145,7 +144,7 @@ pub enum MedlineRnType {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 /// Medline substance records
 pub struct MedlineRn {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     /// type of record
     pub r#type: MedlineRnType,
 
@@ -160,7 +159,7 @@ pub struct MedlineRn {
 /// medline cross reference records
 pub struct MedlineSi {
     /// type of xref
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: MedlineSiType,
     pub cit: Option<String>,
 }
@@ -186,7 +185,7 @@ pub enum MedlineFieldType {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct MedlineField {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     /// keyed type
     pub r#type: MedlineFieldType,
 
@@ -212,7 +211,7 @@ pub enum DocRefType {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 /// reference to a document
 pub struct DocRef {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: DocRefType,
     pub uid: u64,
 }

--- a/src/asn/pub.rs
+++ b/src/asn/pub.rs
@@ -13,6 +13,7 @@ use crate::biblio::{
 use crate::medline::MedlineEntry;
 use serde::{Serialize, Deserialize};
 use crate::{XMLElement, XMLElementVec};
+use crate::parsing_utils::read_node;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -66,15 +67,15 @@ impl XMLElement for Pub {
 
                     if name == sub_element.name() {
                         return Pub::Sub(
-                            CitSub::from_reader(reader)
-                                .unwrap()
-                        ).into()
+                            read_node(reader)
+                                .unwrap())
+                            .into()
                     }
                     else if name == gen_element.name() {
                         return Pub::Gen(
-                            CitGen::from_reader(reader)
-                                .unwrap()
-                        ).into()
+                            read_node(reader)
+                                .unwrap())
+                            .into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/pub.rs
+++ b/src/asn/pub.rs
@@ -8,8 +8,8 @@ use crate::biblio::{
     CitArt, CitBook, CitGen, CitJour, CitLet, CitPat, CitProc, CitSub, IdPat, PubMedId,
 };
 use crate::medline::MedlineEntry;
-use crate::parsing_utils::read_node;
-use crate::{XmlNode, XmlVecNode};
+use crate::parsing::read_node;
+use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};

--- a/src/asn/pub.rs
+++ b/src/asn/pub.rs
@@ -12,7 +12,7 @@ use crate::biblio::{
 };
 use crate::medline::MedlineEntry;
 use serde::{Serialize, Deserialize};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -87,6 +87,7 @@ impl XMLElement for Pub {
         }
     }
 }
+impl XMLElementVec for Pub {}
 
 pub type PubEquiv = Vec<Pub>;
 

--- a/src/asn/pub.rs
+++ b/src/asn/pub.rs
@@ -4,19 +4,18 @@
 //!
 //! Adapted from ["pub.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/pub/pub.asn)
 
-use quick_xml::events::{BytesStart, Event};
-use quick_xml::Reader;
 use crate::biblio::{
-    CitArt, CitBook, CitGen, CitJour, CitLet, CitPat, CitProc, CitSub, IdPat,
-    PubMedId,
+    CitArt, CitBook, CitGen, CitJour, CitLet, CitPat, CitProc, CitSub, IdPat, PubMedId,
 };
 use crate::medline::MedlineEntry;
-use serde::{Serialize, Deserialize};
-use crate::{XMLElement, XMLElementVec};
 use crate::parsing_utils::read_node;
+use crate::{XMLElement, XMLElementVec};
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum Pub {
     /// general or generic unparsed
     Gen(CitGen),
@@ -55,7 +54,10 @@ impl XMLElement for Pub {
         BytesStart::new("Pub")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let sub_element = BytesStart::new("Pub_sub");
         let gen_element = BytesStart::new("Pub_gen");
@@ -66,24 +68,17 @@ impl XMLElement for Pub {
                     let name = e.name();
 
                     if name == sub_element.name() {
-                        return Pub::Sub(
-                            read_node(reader)
-                                .unwrap())
-                            .into()
-                    }
-                    else if name == gen_element.name() {
-                        return Pub::Gen(
-                            read_node(reader)
-                                .unwrap())
-                            .into()
+                        return Pub::Sub(read_node(reader).unwrap()).into();
+                    } else if name == gen_element.name() {
+                        return Pub::Gen(read_node(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -97,13 +92,16 @@ impl XMLElement for PubEquiv {
         BytesStart::new("Pub-equiv")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        return Pub::vec_from_reader(reader, Self::start_bytes().to_end()).into()
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        return Pub::vec_from_reader(reader, Self::start_bytes().to_end()).into();
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum PubSet {
     Pub(Vec<Pub>),
     Medline(Vec<MedlineEntry>),

--- a/src/asn/pub.rs
+++ b/src/asn/pub.rs
@@ -9,7 +9,7 @@ use crate::biblio::{
 };
 use crate::medline::MedlineEntry;
 use crate::parsing_utils::read_node;
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
@@ -49,7 +49,7 @@ pub enum Pub {
     PmId(PubMedId),
 }
 
-impl XMLElement for Pub {
+impl XmlNode for Pub {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Pub")
     }
@@ -83,11 +83,11 @@ impl XMLElement for Pub {
         }
     }
 }
-impl XMLElementVec for Pub {}
+impl XmlVecNode for Pub {}
 
 pub type PubEquiv = Vec<Pub>;
 
-impl XMLElement for PubEquiv {
+impl XmlNode for PubEquiv {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Pub-equiv")
     }

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -21,7 +21,7 @@ use crate::seqtable::SeqTable;
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::parsing_utils::{try_next_int, try_next_string};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="kebab-case")]
@@ -226,6 +226,7 @@ impl XMLElement for SeqDesc {
         }
     }
 }
+impl XMLElementVec for SeqDesc {}
 
 enum_from_primitive! {
     #[allow(non_camel_case_types)]

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -5,7 +5,7 @@
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{check_unexpected, read_vec_node, read_attributes, read_int, read_node, read_string};
+use crate::parsing::{check_unexpected, read_vec_node, read_attributes, read_int, read_node, read_string};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
@@ -13,7 +13,7 @@ use crate::seqfeat::{BioSource, ModelEvidenceSupport, OrgRef, SeqFeat};
 use crate::seqloc::{SeqId, SeqLoc};
 use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
-use crate::{XmlNode, XmlVecNode, XmlValue};
+use crate::parsing::{XmlNode, XmlVecNode, XmlValue};
 use enum_primitive::FromPrimitive;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::events::attributes::Attributes;

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -20,7 +20,7 @@ use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{try_next_int, try_next_string};
+use crate::parsing_utils::{next_int, next_string};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -209,7 +209,7 @@ impl XMLElement for SeqDesc {
                         return Self::Pub(PubDesc::from_reader(reader).unwrap()).into()
                     }
                     else if name == comment_element.name() {
-                        return Self::Comment(try_next_string(reader).unwrap()).into()
+                        return Self::Comment(next_string(reader).unwrap()).into()
                     }
                     else if name == user_element.name() {
                         return Self::User(UserObject::from_reader(reader).unwrap()).into()
@@ -275,7 +275,7 @@ impl XMLElement for BioMol {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        BioMol::from_u8(try_next_int::<u8>(reader).unwrap())
+        BioMol::from_u8(next_int::<u8>(reader).unwrap())
     }
 }
 
@@ -351,7 +351,7 @@ impl XMLElement for MolTech {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        MolTech::from_u8(try_next_int::<u8>(reader).unwrap())
+        MolTech::from_u8(next_int::<u8>(reader).unwrap())
     }
 }
 

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -4,9 +4,8 @@
 //!
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
-use std::ops::Deref;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{parse_attribute_to, parse_attribute_to_option, parse_int_to, parse_int_to_option, parse_node_to, parse_node_to_option, parse_vec_node, parse_vec_node_to, read_int, read_node, read_string};
+use crate::parsing_utils::{parse_attribute_to, parse_int_to_option, parse_node_to, parse_node_to_option, parse_vec_node, parse_vec_node_to, read_int, read_node, read_string};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
@@ -65,7 +64,7 @@ impl XmlNode for BioSeq {
         let id_elem = BytesStart::new("Bioseq_id");
         let descr_elem = BytesStart::new("Bioseq_descr");
         let inst_elem = BytesStart::new("Bioseq_inst");
-        let annot_elem = BytesStart::new("Bioseq_annot");
+        let _annot_elem = BytesStart::new("Bioseq_annot");
 
         loop {
             match reader.read_event().unwrap() {
@@ -750,7 +749,6 @@ impl XmlValue for Repr {
                 if attr.key == value.name() {
                     let _inner = attr.unescape_value().unwrap().to_string();
                     let inner = _inner.get(2.._inner.len()-2).unwrap();
-                    println!("{}", inner);
                     if inner == "not-set" {
                         return Self::NotSet.into()
                     }
@@ -946,10 +944,8 @@ impl XmlNode for SeqInst {
                     parse_node_to_option(&name, &ext_element, &mut inst.ext, reader);
                 }
                 Event::Empty(e) => {
-                    let name = e.name();
-
-                    parse_attribute_to(&e, &repr_element, &mut inst.repr, reader);
-                    parse_attribute_to(&e, &mol_element, &mut inst.mol, reader);
+                    parse_attribute_to(&e, &repr_element, &mut inst.repr);
+                    parse_attribute_to(&e, &mol_element, &mut inst.mol);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -15,7 +15,7 @@ use crate::seqfeat::{BioSource, ModelEvidenceSupport, OrgRef, SeqFeat};
 use crate::seqloc::{SeqId, SeqLoc};
 use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use enum_primitive::FromPrimitive;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
@@ -54,7 +54,7 @@ pub struct BioSeq {
     pub annot: Option<Vec<SeqAnnot>>,
 }
 
-impl XMLElement for BioSeq {
+impl XmlNode for BioSeq {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Bioseq")
     }
@@ -88,7 +88,7 @@ impl XMLElement for BioSeq {
 
 pub type SeqDescr = Vec<SeqDesc>;
 
-impl XMLElement for SeqDescr {
+impl XmlNode for SeqDescr {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seq-descr")
     }
@@ -166,7 +166,7 @@ pub enum SeqDesc {
     ModelEv(ModelEvidenceSupport),
 }
 
-impl XMLElement for SeqDesc {
+impl XmlNode for SeqDesc {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seqdesc")
     }
@@ -212,7 +212,7 @@ impl XMLElement for SeqDesc {
         }
     }
 }
-impl XMLElementVec for SeqDesc {}
+impl XmlVecNode for SeqDesc {}
 
 enum_from_primitive! {
     #[allow(non_camel_case_types)]
@@ -255,7 +255,7 @@ enum_from_primitive! {
     }
 }
 
-impl XMLElement for BioMol {
+impl XmlNode for BioMol {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("MolInfo_biomol")
     }
@@ -334,7 +334,7 @@ enum_from_primitive! {
     }
 }
 
-impl XMLElement for MolTech {
+impl XmlNode for MolTech {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("MolInfo_tech")
     }
@@ -384,7 +384,7 @@ pub struct MolInfo {
     pub gb_mol_type: Option<String>,
 }
 
-impl XMLElement for MolInfo {
+impl XmlNode for MolInfo {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("MolInfo")
     }
@@ -636,7 +636,7 @@ pub struct PubDesc {
     pub ref_type: PubDescRefType,
 }
 
-impl XMLElement for PubDesc {
+impl XmlNode for PubDesc {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Pubdesc")
     }

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -5,7 +5,7 @@
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing::{read_vec_node, read_attributes, read_int, read_node, read_string, UnexpectedTags};
+use crate::parsing::{read_vec_node, read_attributes, read_int, read_node, read_string, UnexpectedTags, attribute_value};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
@@ -762,46 +762,23 @@ impl XmlValue for Repr {
     }
 
     fn from_attributes(attributes: Attributes) -> Option<Self> {
-        let value = BytesStart::new("value");
-        for attribute in attributes {
-            if let Ok(attr) = attribute {
-                if attr.key == value.name() {
-                    let _inner = attr.unescape_value().unwrap().to_string();
-                    let inner = _inner.get(2.._inner.len()-2).unwrap();
-                    if inner == "not-set" {
-                        return Self::NotSet.into()
-                    }
-                    if inner == "virtual" {
-                        return Self::Virtual.into()
-                    }
-                    if inner == "raw" {
-                        return Self::Raw.into()
-                    }
-                    if inner == "seg" {
-                        return Self::Seg.into()
-                    }
-                    if inner == "const" {
-                        return Self::Const.into()
-                    }
-                    if inner == "ref" {
-                        return Self::Ref.into()
-                    }
-                    if inner == "consen" {
-                        return Self::Consen.into()
-                    }
-                    if inner == "map" {
-                        return Self::Map.into()
-                    }
-                    if inner == "delta" {
-                        return Self::Delta.into()
-                    }
-                    if inner == "other" {
-                        return Self::Other.into()
-                    }
-                }
+        if let Some(attributes) = attribute_value(attributes) {
+            match attributes.as_str() {
+                "not-set" => Self::NotSet.into(),
+                "virtual" => Self::Virtual.into(),
+                "raw" => Self::Raw.into(),
+                "seg" => Self::Seg.into(),
+                "const" => Self::Const.into(),
+                "ref" => Self::Ref.into(),
+                "consen" => Self::Consen.into(),
+                "map" => Self::Map.into(),
+                "delta" => Self::Delta.into(),
+                "other" => Self::Other.into(),
+                _ => None
             }
+        } else {
+            None
         }
-        return None
     }
 }
 
@@ -830,25 +807,19 @@ impl XmlValue for Mol {
     }
 
     fn from_attributes(attributes: Attributes) -> Option<Self> {
-        let value = BytesStart::new("value");
-        for attribute in attributes {
-            if let Ok(attr) = attribute {
-                if attr.key == value.name() {
-                    let _inner = attr.unescape_value().unwrap().to_string();
-                    let inner = _inner.get(2.._inner.len()-2).unwrap();
-                    return match inner {
-                        "not-set" => Self::NotSet.into(),
-                        "dna" => Self::DNA.into(),
-                        "rna" => Self::NotSet.into(),
-                        "aa" => Self::DNA.into(),
-                        "na" => Self::DNA.into(),
-                        "other" => Self::Other.into(),
-                        _ => None
-                    }
-                }
+        if let Some(attributes) = attribute_value(attributes) {
+            match attributes.as_str() {
+                "not-set" => Self::NotSet.into(),
+                "dna" => Self::DNA.into(),
+                "rna" => Self::NotSet.into(),
+                "aa" => Self::DNA.into(),
+                "na" => Self::DNA.into(),
+                "other" => Self::Other.into(),
+                _ => None
             }
+        } else {
+            None
         }
-        return None
     }
 }
 

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -178,6 +178,7 @@ impl XMLElement for SeqDesc {
         let pub_element = BytesStart::new("Seqdesc_pub");
         let comment_element = BytesStart::new("Seqdesc_comment");
         let user_element = BytesStart::new("Seqdesc_user");
+        let create_element = BytesStart::new("Seqdesc_create-date");
 
         loop {
             match reader.read_event().unwrap() {
@@ -193,6 +194,8 @@ impl XMLElement for SeqDesc {
                         return Self::Comment(read_string(reader).unwrap()).into();
                     } else if name == user_element.name() {
                         return Self::User(read_node(reader).unwrap()).into();
+                    } else if name == create_element.name() {
+                        return Self::CreateDate(read_node(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -20,7 +20,7 @@ use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::get_next_num;
+use crate::parsing_utils::{get_next_num, get_next_text};
 use crate::XMLElement;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -192,6 +192,7 @@ impl XMLElement for SeqDesc {
         let source_element = BytesStart::new("Seqdesc_source");
         let molinfo_element = BytesStart::new("Seqdesc_molinfo");
         let pub_element = BytesStart::new("Seqdesc_pub");
+        let comment_element = BytesStart::new("Seqdesc_comment");
 
         loop {
             match reader.read_event().unwrap() {
@@ -205,6 +206,9 @@ impl XMLElement for SeqDesc {
                     }
                     else if name == pub_element.name() {
                         return Self::Pub(PubDesc::from_reader(reader).unwrap()).into()
+                    }
+                    else if name == comment_element.name() {
+                        return Self::Comment(get_next_text(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -611,7 +611,7 @@ pub enum PubDescRefType {
     NoTarget,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(rename_all="kebab-case")]
 pub struct PubDesc {
     pub r#pub: PubEquiv,

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -5,7 +5,7 @@
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing::{check_unexpected, read_vec_node, read_attributes, read_int, read_node, read_string};
+use crate::parsing::{read_vec_node, read_attributes, read_int, read_node, read_string, UnexpectedTags};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
@@ -404,6 +404,8 @@ impl XmlNode for MolInfo {
         let bio_mol_element = BytesStart::new("MolInfo_biomol");
         let tech_element = BytesStart::new("MolInfo_tech");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -414,7 +416,7 @@ impl XmlNode for MolInfo {
                     } else if name == tech_element.name() {
                         mol_info.tech = read_node(reader).unwrap();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -661,6 +663,8 @@ impl XmlNode for PubDesc {
         // elements
         let pub_element = BytesStart::new("Pubdesc_pub");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -669,7 +673,7 @@ impl XmlNode for PubDesc {
                     if name == pub_element.name() {
                         desc.r#pub = read_node(reader).unwrap();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -950,6 +954,8 @@ impl XmlNode for SeqInst {
         let length_element = BytesStart::new("Seq-inst_length");
         let ext_element = BytesStart::new("Seq-inst_ext");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -960,7 +966,7 @@ impl XmlNode for SeqInst {
                     } else if name == ext_element.name() {
                         inst.ext = read_node(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[])
+                        forbidden.check(&name);
                     }
                 }
                 Event::Empty(e) => {
@@ -971,7 +977,7 @@ impl XmlNode for SeqInst {
                     } else if name == mol_element.name() {
                         inst.mol = read_attributes(&e).unwrap();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -1460,6 +1466,8 @@ impl XmlNode for SeqAnnot {
         // attribute tags
         let data_tag = BytesStart::new("Seq-annot_data");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -1468,7 +1476,7 @@ impl XmlNode for SeqAnnot {
                     if name == data_tag.name() {
                         annot.data = read_node(reader).unwrap();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -826,6 +826,24 @@ pub struct SeqInst {
     pub hist: Option<SeqHist>,
 }
 
+impl Default for SeqInst {
+    fn default() -> Self {
+        let repr = Repr::Other;
+        let mol = Mol::Other;
+        let strand = Strand::Other;
+        Self {
+            repr, mol,
+            length: None,
+            fuzz: None,
+            topology: Default::default(),
+            strand,
+            seq_data: None,
+            ext: None,
+            hist: None,
+        }
+    }
+}
+
 // Sequence extensions for representing more complex types
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -413,7 +413,7 @@ impl XmlNode for MolInfo {
                         mol_info.bio_mol = read_node(reader).unwrap();
                     } else if name == tech_element.name() {
                         mol_info.tech = read_node(reader).unwrap();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -668,7 +668,7 @@ impl XmlNode for PubDesc {
 
                     if name == pub_element.name() {
                         desc.r#pub = read_node(reader).unwrap();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -959,7 +959,7 @@ impl XmlNode for SeqInst {
                         inst.length = read_int(reader);
                     } else if name == ext_element.name() {
                         inst.ext = read_node(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[])
                     }
                 }
@@ -970,7 +970,7 @@ impl XmlNode for SeqInst {
                         inst.repr = read_attributes(&e).unwrap();
                     } else if name == mol_element.name() {
                         inst.mol = read_attributes(&e).unwrap();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -1467,7 +1467,7 @@ impl XmlNode for SeqAnnot {
 
                     if name == data_tag.name() {
                         annot.data = read_node(reader).unwrap();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -4,27 +4,26 @@
 //!
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
-use enum_primitive::FromPrimitive;
-use quick_xml::events::{BytesStart, Event};
-use quick_xml::Reader;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
+use crate::parsing_utils::{
+    parse_node_to, parse_node_to_option, parse_vec_node_to, read_int, read_node, read_string,
+};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
-use crate::seqfeat::{
-    BioSource, ModelEvidenceSupport, OrgRef,
-    SeqFeat,
-};
+use crate::seqfeat::{BioSource, ModelEvidenceSupport, OrgRef, SeqFeat};
 use crate::seqloc::{SeqId, SeqLoc};
 use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
-use serde::{Serialize, Deserialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{parse_node_to, parse_node_to_option, parse_vec_node_to, read_int, read_node, read_string};
 use crate::{XMLElement, XMLElementVec};
+use enum_primitive::FromPrimitive;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Single continuous biological sequence.
 ///
 /// It can be nucleic acid or protein. It can be fully instantiated (ie: data
@@ -78,10 +77,10 @@ impl XMLElement for BioSeq {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return bioseq.into()
+                        return bioseq.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -95,12 +94,12 @@ impl XMLElement for SeqDescr {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
-        return SeqDesc::vec_from_reader(reader, Self::start_bytes().to_end()).into()
+        return SeqDesc::vec_from_reader(reader, Self::start_bytes().to_end()).into();
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// # Note
 /// `MolType`, `Modif`, `Method`, and `Org` are consolidated and expanded
 /// in [`OrgRef`]`, [`BioSource`], and [`MolInfo`] in this specification.
@@ -185,19 +184,15 @@ impl XMLElement for SeqDesc {
                 Event::Start(e) => {
                     let name = e.name();
                     if name == source_element.name() {
-                        return Self::Source(read_node(reader).unwrap()).into()
-                    }
-                    else if name == molinfo_element.name() {
-                        return Self::MolInfo(read_node(reader).unwrap()).into()
-                    }
-                    else if name == pub_element.name() {
-                        return Self::Pub(read_node(reader).unwrap()).into()
-                    }
-                    else if name == comment_element.name() {
-                        return Self::Comment(read_string(reader).unwrap()).into()
-                    }
-                    else if name == user_element.name() {
-                        return Self::User(read_node(reader).unwrap()).into()
+                        return Self::Source(read_node(reader).unwrap()).into();
+                    } else if name == molinfo_element.name() {
+                        return Self::MolInfo(read_node(reader).unwrap()).into();
+                    } else if name == pub_element.name() {
+                        return Self::Pub(read_node(reader).unwrap()).into();
+                    } else if name == comment_element.name() {
+                        return Self::Comment(read_string(reader).unwrap()).into();
+                    } else if name == user_element.name() {
+                        return Self::User(read_node(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
@@ -206,7 +201,7 @@ impl XMLElement for SeqDesc {
                         return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -259,7 +254,10 @@ impl XMLElement for BioMol {
         BytesStart::new("MolInfo_biomol")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         BioMol::from_u8(read_int::<u8>(reader).unwrap())
     }
 }
@@ -335,7 +333,10 @@ impl XMLElement for MolTech {
         BytesStart::new("MolInfo_tech")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         MolTech::from_u8(read_int::<u8>(reader).unwrap())
     }
 }
@@ -367,7 +368,7 @@ pub enum MolCompleteness {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct MolInfo {
     pub bio_mol: BioMol,
     pub tech: MolTech,
@@ -382,9 +383,11 @@ impl XMLElement for MolInfo {
         BytesStart::new("MolInfo")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut mol_info = Self::default();
-
 
         let bio_mol_element = BytesStart::new("MolInfo_biomol");
         let tech_element = BytesStart::new("MolInfo_tech");
@@ -399,10 +402,10 @@ impl XMLElement for MolInfo {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return mol_info.into()
+                        return mol_info.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -511,7 +514,7 @@ pub enum GIBBMethod {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Any display numbering system
 pub enum Numbering {
     /// continuous numbering
@@ -525,7 +528,7 @@ pub enum Numbering {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// continuous display numbering system
 pub struct NumCont {
     /// number assigned to first residue
@@ -542,7 +545,7 @@ pub struct NumCont {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// any tags to residues
 pub struct NumEnum {
     /// number of tags to follow
@@ -568,7 +571,7 @@ pub enum NumRefType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Number by reference to other sequences
 pub struct NumRef {
     /// type of reference
@@ -578,7 +581,7 @@ pub struct NumRef {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Mapping to floating point system
 /// from an integer system used by [`BioSeq`]
 /// `position = (a * int_position) + b`
@@ -589,7 +592,7 @@ pub struct NumReal {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// type of reference in a GenBank record
 pub enum PubDescRefType {
     #[default]
@@ -604,7 +607,7 @@ pub enum PubDescRefType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct PubDesc {
     pub r#pub: PubEquiv,
     pub name: Option<String>,
@@ -632,7 +635,10 @@ impl XMLElement for PubDesc {
         BytesStart::new("Pubdesc")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut desc = Self::default();
 
         // elements
@@ -647,10 +653,10 @@ impl XMLElement for PubDesc {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return desc.into()
+                        return desc.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -780,7 +786,7 @@ pub enum Strand {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Instances of sequences
 ///
 /// Represents things like: is DNA, RNA, or protein? Is it circular or linear?
@@ -817,7 +823,7 @@ pub struct SeqInst {
 // Sequence extensions for representing more complex types
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum SeqExt {
     /// segmented sequences
     Seg(SegExt),
@@ -837,7 +843,7 @@ pub type MapExt = Vec<SeqFeat>;
 pub type DeltaExt = Vec<DeltaSeq>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum DeltaSeq {
     /// point to a sequence
     Loc(SeqLoc),
@@ -847,7 +853,7 @@ pub enum DeltaSeq {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqLiteral {
     /// must give a length in residues
     pub length: u64,
@@ -860,7 +866,7 @@ pub struct SeqLiteral {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// internal structure for storing sequence history deletion status
 pub enum SeqHistDeleted {
     Bool(bool),
@@ -868,7 +874,7 @@ pub enum SeqHistDeleted {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Sequence history record
 /// assembly: records how seq was assembled from others
 pub struct SeqHist {
@@ -879,14 +885,14 @@ pub struct SeqHist {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqHistRec {
     pub date: Option<Date>,
     pub ids: Vec<SeqId>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Sequence representations
 pub enum SeqData {
     /// IUPAC 1 letter nuc acid code
@@ -965,7 +971,7 @@ pub enum SeqGapLinkage {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqGap {
     pub r#type: SeqGapType,
     pub linkage: Option<SeqGapLinkage>,
@@ -991,7 +997,7 @@ pub enum LinkageEvidenceType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct LinkageEvidence {
     pub r#type: LinkageEvidenceType,
 }
@@ -1042,7 +1048,7 @@ pub type NCBIPaa = Vec<u8>;
 pub type NCBIStdAa = Vec<u8>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// This is a replica of [`TextSeqId`]
 ///
 /// This is specific for annotations, and exists to maintain a semantic difference
@@ -1055,7 +1061,7 @@ pub struct TextAnnotId {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum AnnotId {
     Local(ObjectId),
     NCBI(u64),
@@ -1066,7 +1072,7 @@ pub enum AnnotId {
 pub type AnnotDescr = Vec<AnnotDesc>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum AnnotDesc {
     /// a short name for this collection
     Name(String),
@@ -1109,7 +1115,7 @@ pub enum AlignType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct AlignDef {
     pub align_type: AlignType,
     /// used for the one ref [`SeqId`] for now
@@ -1136,7 +1142,7 @@ pub enum SeqAnnotDB {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Internal representation for `data` choice in [`SeqAnnot`]
 pub enum SeqAnnotData {
     FTable(Vec<SeqFeat>),
@@ -1149,13 +1155,13 @@ pub enum SeqAnnotData {
     /// used for communication between tools
     Locs(Vec<SeqLoc>),
 
-    #[serde(rename="seq-table")]
+    #[serde(rename = "seq-table")]
     /// features in table form
     SeqTable(SeqTable),
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqAnnot {
     pub id: Option<Vec<AnnotId>>,
     pub db: Option<SeqAnnotDB>,

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -193,6 +193,7 @@ impl XMLElement for SeqDesc {
         let molinfo_element = BytesStart::new("Seqdesc_molinfo");
         let pub_element = BytesStart::new("Seqdesc_pub");
         let comment_element = BytesStart::new("Seqdesc_comment");
+        let user_element = BytesStart::new("Seqdesc_user");
 
         loop {
             match reader.read_event().unwrap() {
@@ -209,6 +210,9 @@ impl XMLElement for SeqDesc {
                     }
                     else if name == comment_element.name() {
                         return Self::Comment(get_next_text(reader).unwrap()).into()
+                    }
+                    else if name == user_element.name() {
+                        return Self::User(UserObject::from_reader(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -179,6 +179,7 @@ impl XMLElement for SeqDesc {
         let comment_element = BytesStart::new("Seqdesc_comment");
         let user_element = BytesStart::new("Seqdesc_user");
         let create_element = BytesStart::new("Seqdesc_create-date");
+        let update_element = BytesStart::new("Seqdesc_update-date");
 
         loop {
             match reader.read_event().unwrap() {
@@ -196,6 +197,8 @@ impl XMLElement for SeqDesc {
                         return Self::User(read_node(reader).unwrap()).into();
                     } else if name == create_element.name() {
                         return Self::CreateDate(read_node(reader).unwrap()).into()
+                    } else if name == update_element.name() {
+                        return Self::UpdateDate(read_node(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -20,7 +20,7 @@ use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{get_next_num, get_next_text};
+use crate::parsing_utils::{try_next_int, try_next_string};
 use crate::XMLElement;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -209,7 +209,7 @@ impl XMLElement for SeqDesc {
                         return Self::Pub(PubDesc::from_reader(reader).unwrap()).into()
                     }
                     else if name == comment_element.name() {
-                        return Self::Comment(get_next_text(reader).unwrap()).into()
+                        return Self::Comment(try_next_string(reader).unwrap()).into()
                     }
                     else if name == user_element.name() {
                         return Self::User(UserObject::from_reader(reader).unwrap()).into()
@@ -274,7 +274,7 @@ impl XMLElement for BioMol {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        BioMol::from_u8(get_next_num::<u8>(reader))
+        BioMol::from_u8(try_next_int::<u8>(reader).unwrap())
     }
 }
 
@@ -350,7 +350,7 @@ impl XMLElement for MolTech {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        MolTech::from_u8(get_next_num::<u8>(reader))
+        MolTech::from_u8(try_next_int::<u8>(reader).unwrap())
     }
 }
 

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -58,7 +58,7 @@ impl XMLElement for BioSeq {
         BytesStart::new("Bioseq")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         let mut id = Vec::new();
         let mut descr = None;
         let mut inst = None;
@@ -90,7 +90,7 @@ impl XMLElement for BioSeq {
             descr,
             inst,
             annot
-        }
+        }.into()
     }
 }
 

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -5,7 +5,7 @@
 //! Adapted from ["seq.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seq/seq.asn)
 
 use crate::general::{Date, DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{check_unimplemented, read_vec_node, read_attributes, read_int, read_node, read_string};
+use crate::parsing_utils::{check_unexpected, read_vec_node, read_attributes, read_int, read_node, read_string};
 use crate::r#pub::PubEquiv;
 use crate::seqalign::SeqAlign;
 use crate::seqblock::{EMBLBlock, GBBlock, PDBBlock, PIRBlock, PRFBlock, SPBlock};
@@ -414,7 +414,7 @@ impl XmlNode for MolInfo {
                     } else if name == tech_element.name() {
                         mol_info.tech = read_node(reader).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -669,7 +669,7 @@ impl XmlNode for PubDesc {
                     if name == pub_element.name() {
                         desc.r#pub = read_node(reader).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -960,7 +960,7 @@ impl XmlNode for SeqInst {
                     } else if name == ext_element.name() {
                         inst.ext = read_node(reader);
                     } else {
-                        check_unimplemented(&name, &[])
+                        check_unexpected(&name, &[])
                     }
                 }
                 Event::Empty(e) => {
@@ -971,7 +971,7 @@ impl XmlNode for SeqInst {
                     } else if name == mol_element.name() {
                         inst.mol = read_attributes(&e).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -1468,7 +1468,7 @@ impl XmlNode for SeqAnnot {
                     if name == data_tag.name() {
                         annot.data = read_node(reader).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seq.rs
+++ b/src/asn/seq.rs
@@ -20,7 +20,7 @@ use crate::seqres::SeqGraph;
 use crate::seqtable::SeqTable;
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{next_int, next_string};
+use crate::parsing_utils::{read_int, read_string};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -209,7 +209,7 @@ impl XMLElement for SeqDesc {
                         return Self::Pub(PubDesc::from_reader(reader).unwrap()).into()
                     }
                     else if name == comment_element.name() {
-                        return Self::Comment(next_string(reader).unwrap()).into()
+                        return Self::Comment(read_string(reader).unwrap()).into()
                     }
                     else if name == user_element.name() {
                         return Self::User(UserObject::from_reader(reader).unwrap()).into()
@@ -275,7 +275,7 @@ impl XMLElement for BioMol {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        BioMol::from_u8(next_int::<u8>(reader).unwrap())
+        BioMol::from_u8(read_int::<u8>(reader).unwrap())
     }
 }
 
@@ -351,7 +351,7 @@ impl XMLElement for MolTech {
     }
 
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
-        MolTech::from_u8(next_int::<u8>(reader).unwrap())
+        MolTech::from_u8(read_int::<u8>(reader).unwrap())
     }
 }
 

--- a/src/asn/seqalign.rs
+++ b/src/asn/seqalign.rs
@@ -4,7 +4,7 @@
 
 use crate::general::{ObjectId, UserObject};
 use crate::seqloc::{NaStrand, SeqId, SeqLoc};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 pub type SeqAlignSet = Vec<SeqAlign>;
@@ -32,7 +32,7 @@ pub enum SeqAlignType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SeqAlignSegs {
     DenDiag(Vec<DenseDiag>),
     DenSeg(DenseSeg),
@@ -45,7 +45,7 @@ pub enum SeqAlignSegs {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct SeqAlign {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: SeqAlignType,
     /// dimensionality
     pub dim: Option<u64>,
@@ -155,14 +155,14 @@ pub struct StdSeg {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SplicedSegProduct {
     Transcript,
     Protein,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SplicedSeg {
     /// product is either protein or transcript (cDNA)
     pub product_id: Option<SeqId>,
@@ -204,7 +204,7 @@ pub struct SplicedSeg {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum SplicedSegModifier {
     /// start found for protein/product or genomic alignment
     StartCodonFound(bool),
@@ -214,7 +214,7 @@ pub enum SplicedSegModifier {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Complete or partial exon
 ///
 /// Two consecutive [`SplicedExon`]'s may belong to one exon
@@ -255,7 +255,7 @@ pub struct SplicedExon {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum ProductPos {
     NucPos(u64),
     ProtPos(ProtPos),
@@ -274,7 +274,7 @@ pub struct ProtPos {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Piece of an exon
 ///
 /// Each variant contains lengths given in nucleotide bases
@@ -310,7 +310,7 @@ pub struct SpliceSite {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// [`SparseSeg`] follows the semantics of [`DenseSeg`] and is optimized
 /// for representing sparse multiple alignments.
 pub struct SparseSeg {
@@ -326,7 +326,7 @@ pub struct SparseSeg {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SparseAlign {
     pub first_id: SeqId,
     pub second_id: SeqId,
@@ -355,7 +355,7 @@ pub struct SparseSegExt {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum ScoreValue {
     Real(f64),
     Int(i64),

--- a/src/asn/seqblock.rs
+++ b/src/asn/seqblock.rs
@@ -4,8 +4,8 @@
 //! from the NCBI C++ Toolkit.
 
 use crate::general::{Date, DbTag, ObjectId};
-use crate::seqloc::{SeqId};
-use serde::{Serialize, Deserialize};
+use crate::seqloc::SeqId;
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug)]
@@ -38,7 +38,7 @@ pub enum EMBLDbNameCode {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum EMBLDbName {
     Code(EMBLDbNameCode),
     Name(String),
@@ -122,7 +122,7 @@ pub enum SPBlockClass {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// SWISSPROT specific descriptions
 pub struct SPBlock {
     pub class: SPBlockClass,
@@ -157,7 +157,7 @@ pub struct SPBlock {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// PIR specific descriptions
 pub struct PIRBlock {
     /// had punctuation in sequence?
@@ -185,7 +185,7 @@ pub struct PIRBlock {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct GBBlock {
     pub extra_accessions: Option<Vec<String>>,
     /// source line
@@ -207,7 +207,7 @@ pub struct GBBlock {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Protein Research Foundation specific definition
 pub struct PRFBlock {
     pub extra_src: Option<PRFExtraSrc>,
@@ -224,7 +224,7 @@ pub struct PRFExtraSrc {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// PDB specific descriptions
 pub struct PDBBlock {
     /// deposition date: month,year

--- a/src/asn/seqcode.rs
+++ b/src/asn/seqcode.rs
@@ -6,7 +6,7 @@
 //! increase continuously. So IUPAC codes, which are upper case letters will
 //! always have 65 0 cells before the code begins. This allows all codes to do
 //! indexed lookups.
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug)]
@@ -43,7 +43,7 @@ pub enum SeqCodeType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// for tables of sequence mappings
 pub struct SeqMapTable {
     /// code to map from
@@ -59,7 +59,7 @@ pub struct SeqMapTable {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// internal representation of map index
 pub struct SeqCodeTableCell {
     /// the printed symbol or letter
@@ -69,7 +69,7 @@ pub struct SeqCodeTableCell {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// for names of coded values
 pub struct SeqCodeTable {
     /// name of code

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -264,7 +264,6 @@ impl XmlNode for SeqFeat {
             &partial_tag,
             &except_tag,
             &comment_tag,
-            &product_tag,
             &title_tag,
             &cit_tag,
             &exp_ev_tag,
@@ -283,6 +282,7 @@ impl XmlNode for SeqFeat {
                     let name = e.name();
                     parse_node_to_option(&name, &id_tag, &mut feat.id, reader);
                     parse_node_to_option(&name, &ext_tag, &mut feat.ext, reader);
+                    parse_node_to_option(&name, &product_tag, &mut feat.product, reader);
                     parse_vec_node_to_option(&name, &qual_tag, &mut feat.qual, reader);
                     parse_node_to(&name, &data_tag, &mut feat.data, reader);
                     parse_node_to(&name, &location_tag, &mut feat.location, reader);

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -3,6 +3,54 @@
 //! Adapted from ["seqfeat.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seqfeat/seqfeat.asn)
 //! and documented by [NCBI C++ Toolkit Book](https://ncbi.github.io/cxx-toolkit/pages/ch_datamod#ch_datamod.datamodel.seqfeat)
 //!
+//! A feature table is a collection of sequence features called [`SeqFeat`]s.
+//! A [`SeqFeat`] serves to connect a sequence location ([`SeqLoc`]) with a
+//! specific block of data known as a datablock. Datablocks are defined
+//! objects on their own and are often used in other contexts, such as
+//! publications ([`PubSet`]), references to organisms ([`OrgRef`]), or genes
+//! ([`GeneRef`]). Some datablocks, like coding regions ([`CdRegion`]), only make
+//! sense when considered within the context of a [`SeqLoc`]. However, each
+//! datablock is designed to fulfill a specific purpose and is independent
+//! of others. This means that changes or additions to one datablock do not
+//! affect the others.
+//!
+//! When a pre-existing object from another context is used as a datablock,
+//! any software capable of utilizing that object can also operate on the
+//! feature. For example, code that displays a publication can function with a
+//! publication from a bibliographic database or one used as a sequence
+//! feature without any modifications.
+//!
+//! The [`SeqFeat`] data structure and the [`SeqLoc`] used to attach it to the
+//! sequence are shared among all features. This allows for a set of operations
+//! that can be performed on all features, regardless of the type of datablocks
+//! attached to them. Therefore, a function designed to determine all features
+//! in a specific region of a Bioseq does not need to consider the specific
+//! types of features involved.
+//!
+//! A [`SeqFeat`] is referred to as bipolar because it can have up to two
+//! [`SeqLoc`]s. The [`SeqFeat`].location indicates the "source" and represents
+//! the location on the DNA sequence, similar to the single location in common
+//! feature table implementations. The `product` from [`SeqFeat`] represents
+//! the "sink" and is typically associated with the protein sequence produced.
+//! For example, a [`CdRegion`] feature would have its [`SeqFeat`].location on
+//! the DNA and its [`SeqFeat`].product on the corresponding protein sequence.
+//! This usage defines the process of translating a DNA sequence into a protein
+//! sequence, establishing an explicit relationship between nucleic acid and
+//! protein sequence databases.
+//!
+//! Having two [`SeqLoc`]s allows for a more comprehensive representation of
+//! data conflicts or exceptional biological circumstances. For instance,
+//! if an author presents a DNA sequence and its protein product in a figure,
+//! it is possible to enter the DNA and protein sequences independently and
+//! then confirm through the [`CdRegion`] feature that the DNA indeed translates
+//! to the provided protein sequence. In cases where the DNA and protein do
+//! not match, it could indicate an error in the database or the original
+//! paper. By setting a "conflict" flag in the CdRegion, the problem can be
+//! identified early and addressed. Additionally, there may be situations
+//! where a genomic sequence cannot be translated to a protein due to known
+//! biological reasons, such as RNA editing or suppressor tRNAs. In such
+//! cases, the [`SeqFeat`] can be marked with an "exception" flag to indicate
+//! that the data is correct but may not behave as expected.
 
 /// A feature table is a collection of sequence features called [`SeqFeat`]s.
 /// A [`SeqFeat`] serves to connect a sequence location ([`SeqLoc`]) with a

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -64,7 +64,7 @@ use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{try_next_int, parse_next_string_to};
+use crate::parsing_utils::{next_int, parse_next_string_to};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -1697,7 +1697,7 @@ impl XMLElement for OrgName {
                     parse_next_string_to(&name, &lineage_element, &mut org_name.lineage, reader);
 
                     if name == gcode_element.name() {
-                        org_name.gcode = try_next_int::<u64>(reader);
+                        org_name.gcode = next_int::<u64>(reader);
                     }
 
                     parse_next_string_to(&name, &div_element, &mut org_name.div, reader)

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,7 +54,7 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{check_unimplemented, read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked};
+use crate::parsing_utils::{check_unexpected, read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
@@ -110,7 +110,7 @@ impl XmlNode for FeatId {
                     } else if name == general_tag.name() {
                         return Self::General(read_node(reader).unwrap()).into();
                     } else {
-                        check_unimplemented(&name, &forbidden);
+                        check_unexpected(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {
@@ -295,7 +295,7 @@ impl XmlNode for SeqFeat {
                     } else if name == xref_tag.name() {
                         feat.xref = Some(read_vec_node(reader, xref_tag.to_end()));
                     } else {
-                        check_unimplemented(&name, &forbidden);
+                        check_unexpected(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {
@@ -499,7 +499,7 @@ impl XmlNode for SeqFeatData {
                         return Self::Prot(read_node(reader).unwrap()).into();
                     }
                     else {
-                        check_unimplemented(&name, &forbidden);
+                        check_unexpected(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {
@@ -753,7 +753,7 @@ impl XmlNode for CdRegion {
                     } else if name == stops_tag.name() {
                         cdregion.stops = read_int(reader);
                     } else {
-                        check_unimplemented(&name, &[])
+                        check_unexpected(&name, &[])
                     }
                 }
                 Event::End(e) => {
@@ -905,7 +905,7 @@ impl XmlNode for GbQual {
                     } else if name == val_tag.name() {
                         qual.val = read_string(reader).unwrap();
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -1934,7 +1934,7 @@ impl XmlNode for GeneRef {
                     } else if name == locus_tag_tag.name() {
                         gene.locus_tag = read_string(reader);
                     } else {
-                        check_unimplemented(&name, &forbidden);
+                        check_unexpected(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {
@@ -2012,7 +2012,7 @@ impl XmlNode for OrgRef {
                     } else if name == db_element.name() {
                         org_ref.db = Some(read_vec_node(reader, db_element.to_end()))
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2142,7 +2142,7 @@ impl XmlNode for OrgName {
                     } else if name == mod_element.name() {
                         org_name.r#mod = Some(read_vec_node(reader, mod_element.to_end()));
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2278,7 +2278,7 @@ impl XmlNode for OrgMod {
                     } else if name == attrib_element.name() {
                         r#mod.attrib = read_string(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2330,7 +2330,7 @@ impl XmlNode for BinomialOrgName {
                     } else if name == subspecies_element.name() {
                         binomial.subspecies = read_string(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2480,7 +2480,7 @@ impl XmlNode for BioSource {
                     } else if name == subtype_element.name() {
                         source.subtype = Some(read_vec_node(reader, subtype_element.to_end()))
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2624,7 +2624,7 @@ impl XmlNode for SubSource {
                     } else if qname == attrib_element.name() {
                         source.attrib = read_string(reader);
                     } else {
-                        check_unimplemented(&qname, &[]);
+                        check_unexpected(&qname, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -2710,7 +2710,7 @@ impl XmlNode for ProtRef {
                     } else if name == db_tag.name() {
                         prot.db = read_vec_node(reader, db_tag.to_end()).into();
                     } else {
-                        check_unimplemented(&name, &forbidden);
+                        check_unexpected(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -65,7 +65,7 @@ use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::parsing_utils::{try_next_int, parse_next_string_into};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -1850,6 +1850,7 @@ impl XMLElement for OrgMod {
         }.into()
     }
 }
+impl XMLElementVec for OrgMod {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct BinomialOrgName {
@@ -2214,6 +2215,7 @@ impl XMLElement for SubSource {
         }.into()
     }
 }
+impl XMLElementVec for SubSource {}
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug, Default)]
 #[repr(u8)]

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -433,26 +433,48 @@ impl XmlNode for SeqFeatData {
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
         // variant tags
         let gene_tag = BytesStart::new("SeqFeatData_gene");
-        let _org_tag = BytesStart::new("SeqFeatData_org");
+        let org_tag = BytesStart::new("SeqFeatData_org");
         let cdregion_tag = BytesStart::new("SeqFeatData_cdregion");
-        let _prot_tag = BytesStart::new("SeqFeatData_prot");
-        let _rna_tag = BytesStart::new("SeqFeatData_rna");
-        let _pub_tag = BytesStart::new("SeqFeatData_pub");
-        let _seq_tag = BytesStart::new("SeqFeatData_seq");
-        let _imp_tag = BytesStart::new("SeqFeatData_imp");
-        let _region_tag = BytesStart::new("SeqFeatData_region");
-        let _bond_tag = BytesStart::new("SeqFeatData_bond");
-        let _site_tag = BytesStart::new("SeqFeatData_site");
-        let _rsite_tag = BytesStart::new("SeqFeatData_rsite");
-        let _user_tag = BytesStart::new("SeqFeatData_user");
-        let _txinit_tag = BytesStart::new("SeqFeatData_txinit");
-        let _num_tag = BytesStart::new("SeqFeatData_num");
-        let _psec_str_tag = BytesStart::new("SeqFeatData_psec-str");
-        let _non_std_residue_tag = BytesStart::new("SeqFeatData_non-std-residue");
-        let _het_tag = BytesStart::new("SeqFeatData_het");
-        let _biosrc_tag = BytesStart::new("SeqFeatData_biosrc");
-        let _clone_tag = BytesStart::new("SeqFeatData_clone");
-        let _variation_tag = BytesStart::new("SeqFeatData_variation");
+        let prot_tag = BytesStart::new("SeqFeatData_prot");
+        let rna_tag = BytesStart::new("SeqFeatData_rna");
+        let pub_tag = BytesStart::new("SeqFeatData_pub");
+        let seq_tag = BytesStart::new("SeqFeatData_seq");
+        let imp_tag = BytesStart::new("SeqFeatData_imp");
+        let region_tag = BytesStart::new("SeqFeatData_region");
+        let bond_tag = BytesStart::new("SeqFeatData_bond");
+        let site_tag = BytesStart::new("SeqFeatData_site");
+        let rsite_tag = BytesStart::new("SeqFeatData_rsite");
+        let user_tag = BytesStart::new("SeqFeatData_user");
+        let txinit_tag = BytesStart::new("SeqFeatData_txinit");
+        let num_tag = BytesStart::new("SeqFeatData_num");
+        let psec_str_tag = BytesStart::new("SeqFeatData_psec-str");
+        let non_std_residue_tag = BytesStart::new("SeqFeatData_non-std-residue");
+        let het_tag = BytesStart::new("SeqFeatData_het");
+        let biosrc_tag = BytesStart::new("SeqFeatData_biosrc");
+        let clone_tag = BytesStart::new("SeqFeatData_clone");
+        let variation_tag = BytesStart::new("SeqFeatData_variation");
+
+        let forbidden = [
+            org_tag,
+            prot_tag,
+            rna_tag,
+            pub_tag,
+            seq_tag,
+            imp_tag,
+            region_tag,
+            bond_tag,
+            site_tag,
+            rsite_tag,
+            user_tag,
+            txinit_tag,
+            num_tag,
+            psec_str_tag,
+            non_std_residue_tag,
+            het_tag,
+            biosrc_tag,
+            clone_tag,
+            variation_tag
+        ];
 
         loop {
             match reader.read_event().unwrap() {
@@ -462,8 +484,11 @@ impl XmlNode for SeqFeatData {
                     if name == gene_tag.name() {
                         return Self::Gene(read_node(reader).unwrap()).into()
                     }
-                    if name == cdregion_tag.name() {
+                    else if name == cdregion_tag.name() {
                         return Self::CdRegion(read_node(reader).unwrap()).into()
+                    }
+                    else {
+                        check_unimplemented(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -64,7 +64,7 @@ use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::try_field;
+use crate::parsing_utils::{get_next_num, try_field};
 use crate::XMLElement;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -1697,11 +1697,7 @@ impl XMLElement for OrgName {
                     try_field(&name, &lineage_element, &mut org_name.lineage, reader);
 
                     if name == gcode_element.name() {
-                        if let Event::Text(text) = reader.read_event().unwrap() {
-                            org_name.gcode = atoi::<u64>(text.as_ref())
-                        }
-                        else {
-                        }
+                        org_name.gcode = Some(get_next_num::<u64>(reader));
                     }
 
                     try_field(&name, &div_element, &mut org_name.div, reader)

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -52,22 +52,25 @@
 //! cases, the [`SeqFeat`] can be marked with an "exception" flag to indicate
 //! that the data is correct but may not behave as expected.
 
+use crate::biblio::{PubMedId, DOI};
+use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
+use crate::parsing_utils::{
+    parse_int_to_option, parse_node_to, parse_node_to_option, parse_string_to,
+    parse_vec_node_to_option, read_int, read_node,
+};
+use crate::r#pub::PubSet;
+use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
+use crate::seqloc::{GiimportId, SeqId, SeqLoc};
+use crate::{XMLElement, XMLElementVec};
 use bitflags::bitflags;
 use enum_primitive::FromPrimitive;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use crate::biblio::{DOI, PubMedId};
-use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::r#pub::PubSet;
-use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
-use crate::seqloc::{GiimportId, SeqId, SeqLoc};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{read_int, parse_string_to, parse_node_to, parse_node_to_option, parse_vec_node_to_option, parse_int_to_option, read_node};
-use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Feature identifiers
 pub enum FeatId {
     /// GenInfo backbone
@@ -100,7 +103,7 @@ pub enum SeqFeatExpEvidence {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Sequence feature generalization
 pub struct SeqFeat {
     pub id: Option<FeatId>,
@@ -232,7 +235,7 @@ pub enum PSecStr {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SeqFeatData {
     Gene(GeneRef),
     Org(OrgRef),
@@ -266,11 +269,11 @@ pub enum SeqFeatData {
     /// a numbering system
     Num(Numbering),
 
-    #[serde(rename="psec-str")]
+    #[serde(rename = "psec-str")]
     /// protein secondary structure
     PSecStr(PSecStr),
 
-    #[serde(rename="non-std-residue")]
+    #[serde(rename = "non-std-residue")]
     /// non-standard residue here in seq
     NonStdResidue(String),
 
@@ -289,7 +292,7 @@ pub struct SeqFeatXref {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqFeatSupport {
     pub experiment: Option<Vec<ExperimentSupport>>,
     pub inference: Option<Vec<InferenceSupport>>,
@@ -358,10 +361,10 @@ pub enum InferenceSupportType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct InferenceSupport {
     pub category: Option<EvidenceCategory>,
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: InferenceSupportType,
     pub other_type: Option<String>,
     // TODO: default to false
@@ -372,7 +375,7 @@ pub struct InferenceSupport {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct ModelEvidenceItem {
     pub id: SeqId,
     pub exon_count: Option<u64>,
@@ -384,7 +387,7 @@ pub struct ModelEvidenceItem {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct ModelEvidenceSupport {
     pub method: Option<String>,
     pub mrna: Option<Vec<ModelEvidenceItem>>,
@@ -417,14 +420,13 @@ pub enum CdRegionFrame {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Instructions to translate from a nucleic acid to a peptide
 pub struct CdRegion {
     /// just an ORF ?
     pub orf: Option<bool>,
 
     pub frame: CdRegionFrame,
-
 
     /// supposed to translate, but doesn't
     pub conflict: Option<bool>,
@@ -457,7 +459,7 @@ pub struct CdRegion {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Storage type for genetic code data
 ///
 /// I do not know what purpose the "start" variants [`Self::SNcbiStdAa`],
@@ -491,7 +493,7 @@ pub enum GeneticCodeOpt {
 pub type GeneticCode = Vec<GeneticCodeOpt>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 /// the amino acid that is the exception
 pub enum CodeBreakAA {
     /// ASCII value of [`crate::asn::NCBIEaa`] code
@@ -569,7 +571,7 @@ pub enum CloneRefPlacementMethod {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Specification of clone features
 pub struct CloneRef {
     /// official clone symbol
@@ -578,9 +580,8 @@ pub struct CloneRef {
     /// library name
     pub library: Option<String>,
 
-
-    pub concordant: bool,       // TODO: default to false
-    pub unique: bool,           // TODO: default to false
+    pub concordant: bool, // TODO: default to false
+    pub unique: bool,     // TODO: default to false
     pub placement_method: Option<CloneRefPlacementMethod>,
     pub clone_seq: Option<CloneSeqSet>,
 }
@@ -664,9 +665,9 @@ pub enum CloneSeqSupport {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct CloneSeq {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: CloneSeqType,
     pub confidence: Option<CloneSeqConfidence>,
 
@@ -682,26 +683,26 @@ pub struct CloneSeq {
 }
 
 bitflags! {
-    #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-    pub struct VariantResourceLink: u8 {
-        /// Clinical, Pubmed, Cited
-        const Preserved = 1;
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct VariantResourceLink: u8 {
+    /// Clinical, Pubmed, Cited
+    const Preserved = 1;
 
-        /// Provisional third party annotations
-        const Provisional = 2;
+    /// Provisional third party annotations
+    const Provisional = 2;
 
-        /// has 3D structure in SNP3D table
-        const Has3D = 4;
+    /// has 3D structure in SNP3D table
+    const Has3D = 4;
 
-        /// SNP -> SubSNP -> Batch link_out
-        const SubmitterLinkout = 8;
+    /// SNP -> SubSNP -> Batch link_out
+    const SubmitterLinkout = 8;
 
-        /// Clinical if LSDB, OMIM, TPA, Diagnostic
-        const Clinical = 16;
+    /// Clinical if LSDB, OMIM, TPA, Diagnostic
+    const Clinical = 16;
 
-        /// Marker exists on high density genotyping kit
-        const GenotypeKit = 32;
-    }}
+    /// Marker exists on high density genotyping kit
+    const GenotypeKit = 32;
+}}
 
 bitflags! {
     #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -878,7 +879,7 @@ pub enum VariantConfidence {
     Other = 255,
 }
 
-bitflags!{
+bitflags! {
     #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
     /// origin of this allele, if known
     ///
@@ -919,7 +920,7 @@ pub enum VariantAlleleState {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Specification of variation features
 ///
 /// The intention is to provide information to clients that reflect internal
@@ -994,7 +995,7 @@ pub enum PhenotypeClinicalSignificance {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct Phenotype {
     pub source: Option<String>,
     pub term: Option<String>,
@@ -1015,7 +1016,7 @@ bitflags! {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct PopulationData {
     /// assayed population (eg: HAPMAP-CEU)
     pub population: String,
@@ -1082,14 +1083,14 @@ pub enum VariationRefDataSetType {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct VariationRefDataSet {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: VariationRefDataSetType,
     pub variations: Vec<VariationRef>,
     pub name: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum VariationRefData {
     Unknown,
 
@@ -1115,7 +1116,7 @@ pub enum VariationRefData {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// see http://www.hgvs.org/mutnomen/recs-prot.html
 pub struct VariationFrameshift {
     pub phase: Option<i64>,
@@ -1123,7 +1124,7 @@ pub struct VariationFrameshift {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct VariationLossOfHeterozygosity {
     /// in germline comparison, it will be reference genome assembly
     /// (default) or referenece/normal population. In somatic mutation,
@@ -1135,7 +1136,7 @@ pub struct VariationLossOfHeterozygosity {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum VariationConsequence {
     Unknown,
 
@@ -1156,7 +1157,7 @@ pub enum VariationConsequence {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SomaticOriginCondition {
     pub description: Option<String>,
 
@@ -1174,7 +1175,7 @@ pub struct VariationSomaticOrigin {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// reference to SNP
 ///
 /// This object relates three IDs:
@@ -1217,7 +1218,7 @@ pub struct VariationRef {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum DeltaSeq {
     Literal(SeqLiteral),
     Loc(SeqLoc),
@@ -1248,7 +1249,7 @@ pub enum DeltaAction {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct DeltaItem {
     pub seq: Option<DeltaSeq>,
 
@@ -1256,7 +1257,7 @@ pub struct DeltaItem {
     ///
     /// This allows describing CNV/SSR where delta=self  with a
     /// multiplier which specifies the count of the repeat unit.
-    pub multiplier: Option<i64>,        // assumed 1 if not specified
+    pub multiplier: Option<i64>, // assumed 1 if not specified
     pub multiplier_fuzz: Option<IntFuzz>,
 
     pub action: DeltaAction,
@@ -1285,7 +1286,7 @@ pub enum VariationInstType {
     /// `delta=[morph of length >1]`
     Mnp,
 
-    #[serde(rename="delins")]
+    #[serde(rename = "delins")]
     /// `delta=[del, ins]`
     DelIns,
 
@@ -1360,7 +1361,7 @@ pub enum VariationInstObservation {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct VariationInst {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: VariationInstType,
 
     /// sequence that replaces the location, in biological order
@@ -1373,7 +1374,7 @@ pub struct VariationInst {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum RSiteRef {
     /// may be unparsable
     Str(String),
@@ -1414,7 +1415,7 @@ pub enum RnaRefType {
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum RnaRefExt {
     /// for naming "other" type
     Name(String),
@@ -1428,14 +1429,14 @@ pub enum RnaRefExt {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct RnaRef {
-    #[serde(rename="type")]
+    #[serde(rename = "type")]
     pub r#type: RnaRefType,
     pub pseudo: Option<bool>,
     pub ext: Option<RnaRefExt>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum TRnaExtAa {
     IUPACAa(u64),
     NCBIEaa(u64),
@@ -1478,7 +1479,7 @@ pub struct RnaQual {
 pub type RnaQualSet = Vec<RnaQual>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct GeneRef {
     /// official gene symbol
     pub locus: Option<String>,
@@ -1570,17 +1571,17 @@ impl XMLElement for OrgRef {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return org_ref.into()
+                        return org_ref.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum OrgNameChoice {
     /// genus/species type name
     Binomial(BinomialOrgName),
@@ -1603,7 +1604,10 @@ impl XMLElement for OrgNameChoice {
         BytesStart::new("OrgName_name")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         // variants
         let binomial_element = BytesStart::new("OrgName_name_binomial");
 
@@ -1613,7 +1617,7 @@ impl XMLElement for OrgNameChoice {
                     let name = e.name();
 
                     if name == binomial_element.name() {
-                        return Self::Binomial(read_node(reader).unwrap()).into()
+                        return Self::Binomial(read_node(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
@@ -1621,7 +1625,7 @@ impl XMLElement for OrgNameChoice {
                         return None;
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -1634,7 +1638,7 @@ pub struct OrgName {
     /// attribution of name
     pub attrib: Option<String>,
 
-    #[serde(rename="mod")]
+    #[serde(rename = "mod")]
     pub r#mod: Option<Vec<OrgMod>>,
 
     /// lineage with semicolon separators
@@ -1661,7 +1665,10 @@ impl XMLElement for OrgName {
         BytesStart::new("OrgName")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut org_name = OrgName::default();
 
         let name_element = BytesStart::new("OrgName_name");
@@ -1685,15 +1692,14 @@ impl XMLElement for OrgName {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return org_name.into()
+                        return org_name.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
 }
-
 
 enum_from_primitive! {
     #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug)]
@@ -1773,7 +1779,10 @@ impl XMLElement for OrgModSubType {
         BytesStart::new("OrgMod_subtype")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         Self::from_u8(read_int(reader).unwrap())
     }
 }
@@ -1792,7 +1801,10 @@ impl XMLElement for OrgMod {
         BytesStart::new("OrgMod")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut r#mod = Self::default();
 
         let subtype_element = BytesStart::new("OrgMod_subtype");
@@ -1810,10 +1822,10 @@ impl XMLElement for OrgMod {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return r#mod.into()
+                        return r#mod.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -1835,7 +1847,10 @@ impl XMLElement for BinomialOrgName {
         BytesStart::new("BinomialOrgName")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized,
+    {
         let mut binomial = BinomialOrgName::default();
 
         let genus_element = BytesStart::new("BinomialOrgName_genus");
@@ -1853,10 +1868,10 @@ impl XMLElement for BinomialOrgName {
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
-                        return binomial.into()
+                        return binomial.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -1880,7 +1895,7 @@ pub enum TaxElementFixedLevel {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct TaxElement {
     pub fixed_level: TaxElementFixedLevel,
     pub level: Option<String>,
@@ -1920,7 +1935,6 @@ enum_from_primitive! {
     }
 }
 
-
 impl XMLElement for BioSourceGenome {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("BioSource_genome")
@@ -1956,7 +1970,7 @@ pub enum BioSourceOrigin {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct BioSource {
     /// biological context
     pub genome: BioSourceGenome,
@@ -1998,10 +2012,10 @@ impl XMLElement for BioSource {
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {
-                        return source.into()
+                        return source.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -2136,10 +2150,10 @@ impl XMLElement for SubSource {
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {
-                        return source.into()
+                        return source.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -2160,7 +2174,7 @@ pub enum ProtRefProcessingStatus {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Reference to a protein name
 pub struct ProtRef {
     /// protein name
@@ -2223,7 +2237,7 @@ pub enum InitType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Transcription Initiation Site feature data block
 pub struct TxInit {
     /// descriptive name of initiation site
@@ -2254,7 +2268,7 @@ pub struct TxInit {
     pub txorg: Option<OrgRef>,
 
     /// mapping precise or approx
-    pub mapping_precise: bool,   // TODO: default false
+    pub mapping_precise: bool, // TODO: default false
 
     /// does [`SeqLoc`] reflect mapping
     pub location_accurate: bool, // TODO: default false
@@ -2317,22 +2331,10 @@ pub enum TxEvidenceExpressionSystem {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct TxEvidence {
     pub exp_code: TxEvidenceExpCode,
     pub expression_system: TxEvidenceExpressionSystem,
     pub low_prec_data: bool, // TODO: default false
     pub from_homolog: bool,  // TODO: default false
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -64,7 +64,7 @@ use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{try_next_int, parse_next_string_into};
+use crate::parsing_utils::{try_next_int, parse_next_string_to};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -1565,7 +1565,7 @@ impl XMLElement for OrgRef {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_next_string_into(&name, &taxname_element, &mut org_ref.taxname, reader);
+                    parse_next_string_to(&name, &taxname_element, &mut org_ref.taxname, reader);
 
                     if name == db_element.name() {
                         org_ref.db = DbTag::vec_from_reader(reader, db_element.to_end()).into();
@@ -1688,19 +1688,19 @@ impl XMLElement for OrgName {
                         org_name.name = OrgNameChoice::from_reader(reader);
                     }
 
-                    parse_next_string_into(&name, &attrib_element, &mut org_name.attrib, reader);
+                    parse_next_string_to(&name, &attrib_element, &mut org_name.attrib, reader);
 
                     if name == mod_element.name() {
                         org_name.r#mod = OrgMod::vec_from_reader(reader, mod_element.to_end()).into();
                     }
 
-                    parse_next_string_into(&name, &lineage_element, &mut org_name.lineage, reader);
+                    parse_next_string_to(&name, &lineage_element, &mut org_name.lineage, reader);
 
                     if name == gcode_element.name() {
                         org_name.gcode = try_next_int::<u64>(reader);
                     }
 
-                    parse_next_string_into(&name, &div_element, &mut org_name.div, reader)
+                    parse_next_string_to(&name, &div_element, &mut org_name.div, reader)
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -1832,7 +1832,7 @@ impl XMLElement for OrgMod {
                         subtype = OrgModSubType::from_reader(reader);
                     }
 
-                    parse_next_string_into(&name, &subname_element, &mut subname, reader);
+                    parse_next_string_to(&name, &subname_element, &mut subname, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -1879,9 +1879,9 @@ impl XMLElement for BinomialOrgName {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_next_string_into(&name, &genus_element, &mut binomial.genus, reader);
-                    parse_next_string_into(&name, &species_element, &mut binomial.species, reader);
-                    parse_next_string_into(&name, &subspecies_element, &mut binomial.subspecies, reader);
+                    parse_next_string_to(&name, &genus_element, &mut binomial.genus, reader);
+                    parse_next_string_to(&name, &species_element, &mut binomial.species, reader);
+                    parse_next_string_to(&name, &subspecies_element, &mut binomial.subspecies, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -2197,7 +2197,7 @@ impl XMLElement for SubSource {
                         subtype = SubSourceSubType::from_reader(reader);
                     }
 
-                    parse_next_string_into(&qname, &name_element, &mut name, reader);
+                    parse_next_string_to(&qname, &name_element, &mut name, reader);
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -64,7 +64,7 @@ use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{get_next_num, try_field};
+use crate::parsing_utils::{try_next_int, parse_next_string_into};
 use crate::XMLElement;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -1565,7 +1565,7 @@ impl XMLElement for OrgRef {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_field(&name, &taxname_element, &mut org_ref.taxname, reader);
+                    parse_next_string_into(&name, &taxname_element, &mut org_ref.taxname, reader);
 
                     if name == db_element.name() {
                         org_ref.db = DbTag::vec_from_reader(reader, db_element.to_end()).into();
@@ -1688,19 +1688,19 @@ impl XMLElement for OrgName {
                         org_name.name = OrgNameChoice::from_reader(reader);
                     }
 
-                    try_field(&name, &attrib_element, &mut org_name.attrib, reader);
+                    parse_next_string_into(&name, &attrib_element, &mut org_name.attrib, reader);
 
                     if name == mod_element.name() {
                         org_name.r#mod = OrgMod::vec_from_reader(reader, mod_element.to_end()).into();
                     }
 
-                    try_field(&name, &lineage_element, &mut org_name.lineage, reader);
+                    parse_next_string_into(&name, &lineage_element, &mut org_name.lineage, reader);
 
                     if name == gcode_element.name() {
-                        org_name.gcode = Some(get_next_num::<u64>(reader));
+                        org_name.gcode = try_next_int::<u64>(reader);
                     }
 
-                    try_field(&name, &div_element, &mut org_name.div, reader)
+                    parse_next_string_into(&name, &div_element, &mut org_name.div, reader)
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -1832,7 +1832,7 @@ impl XMLElement for OrgMod {
                         subtype = OrgModSubType::from_reader(reader);
                     }
 
-                    try_field(&name, &subname_element, &mut subname, reader);
+                    parse_next_string_into(&name, &subname_element, &mut subname, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -1878,9 +1878,9 @@ impl XMLElement for BinomialOrgName {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    try_field(&name, &genus_element, &mut binomial.genus, reader);
-                    try_field(&name, &species_element, &mut binomial.species, reader);
-                    try_field(&name, &subspecies_element, &mut binomial.subspecies, reader);
+                    parse_next_string_into(&name, &genus_element, &mut binomial.genus, reader);
+                    parse_next_string_into(&name, &species_element, &mut binomial.species, reader);
+                    parse_next_string_into(&name, &subspecies_element, &mut binomial.subspecies, reader);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {
@@ -2196,7 +2196,7 @@ impl XMLElement for SubSource {
                         subtype = SubSourceSubType::from_reader(reader);
                     }
 
-                    try_field(&qname, &name_element, &mut name, reader);
+                    parse_next_string_into(&qname, &name_element, &mut name, reader);
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -95,6 +95,11 @@ impl XmlNode for FeatId {
         let local_tag = BytesStart::new("Feat-id_local");
         let general_tag = BytesStart::new("Feat-id_general");
 
+        let forbidden = [
+            &gibb_tag,
+            &giim_tag
+        ];
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -102,6 +107,10 @@ impl XmlNode for FeatId {
 
                     if name == local_tag.name() {
                         return Self::Local(read_node(reader).unwrap()).into();
+                    } else if name == general_tag.name() {
+                        return Self::General(read_node(reader).unwrap()).into();
+                    } else {
+                        check_unimplemented(&name, &forbidden);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,7 +54,7 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing::{check_unexpected, read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked};
+use crate::parsing::{read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked, UnexpectedTags};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
@@ -99,6 +99,7 @@ impl XmlNode for FeatId {
             gibb_tag,
             giim_tag
         ];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -110,7 +111,7 @@ impl XmlNode for FeatId {
                     } else if name == general_tag.name() {
                         return Self::General(read_node(reader).unwrap()).into();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -273,6 +274,7 @@ impl XmlNode for SeqFeat {
             exts_tag,
             support_tag
         ];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -295,7 +297,7 @@ impl XmlNode for SeqFeat {
                     } else if name == xref_tag.name() {
                         feat.xref = Some(read_vec_node(reader, xref_tag.to_end()));
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -483,6 +485,7 @@ impl XmlNode for SeqFeatData {
             clone_tag,
             variation_tag
         ];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -499,7 +502,7 @@ impl XmlNode for SeqFeatData {
                         return Self::Prot(read_node(reader).unwrap()).into();
                     }
                     else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -739,6 +742,8 @@ impl XmlNode for CdRegion {
         let _code_break_tag = BytesStart::new("Cdregion_code-break");
         let stops_tag = BytesStart::new("Cdregion_stops");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -753,7 +758,7 @@ impl XmlNode for CdRegion {
                     } else if name == stops_tag.name() {
                         cdregion.stops = read_int(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[])
+                        forbidden.check(&name)
                     }
                 }
                 Event::End(e) => {
@@ -895,6 +900,8 @@ impl XmlNode for GbQual {
         let qual_tag = BytesStart::new("Gb-qual_qual");
         let val_tag = BytesStart::new("Gb-qual_val");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -905,7 +912,7 @@ impl XmlNode for GbQual {
                     } else if name == val_tag.name() {
                         qual.val = read_string(reader).unwrap();
                     } else {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -1915,6 +1922,7 @@ impl XmlNode for GeneRef {
             syn_tag,
             form_name_tag,
         ];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -1934,7 +1942,7 @@ impl XmlNode for GeneRef {
                     } else if name == locus_tag_tag.name() {
                         gene.locus_tag = read_string(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2000,6 +2008,8 @@ impl XmlNode for OrgRef {
         let db_element = BytesStart::new("Org-ref_db");
         let orgname_element = BytesStart::new("Org-ref_orgname");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2012,7 +2022,7 @@ impl XmlNode for OrgRef {
                     } else if name == db_element.name() {
                         org_ref.db = Some(read_vec_node(reader, db_element.to_end()))
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2124,6 +2134,8 @@ impl XmlNode for OrgName {
         let gcode_element = BytesStart::new("OrgName_gcode");
         let div_element = BytesStart::new("OrgName_div");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2142,7 +2154,7 @@ impl XmlNode for OrgName {
                     } else if name == mod_element.name() {
                         org_name.r#mod = Some(read_vec_node(reader, mod_element.to_end()));
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2266,6 +2278,8 @@ impl XmlNode for OrgMod {
         let subname_element = BytesStart::new("OrgMod_subname");
         let attrib_element = BytesStart::new("OrgMod_attrib");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2278,7 +2292,7 @@ impl XmlNode for OrgMod {
                     } else if name == attrib_element.name() {
                         r#mod.attrib = read_string(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2318,6 +2332,8 @@ impl XmlNode for BinomialOrgName {
         let species_element = BytesStart::new("BinomialOrgName_species");
         let subspecies_element = BytesStart::new("BinomialOrgName_subspecies");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2330,7 +2346,7 @@ impl XmlNode for BinomialOrgName {
                     } else if name == subspecies_element.name() {
                         binomial.subspecies = read_string(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2468,6 +2484,8 @@ impl XmlNode for BioSource {
         let org_element = BytesStart::new("BioSource_org");
         let subtype_element = BytesStart::new("BioSource_subtype");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2480,7 +2498,7 @@ impl XmlNode for BioSource {
                     } else if name == subtype_element.name() {
                         source.subtype = Some(read_vec_node(reader, subtype_element.to_end()))
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -2612,6 +2630,8 @@ impl XmlNode for SubSource {
         let name_element = BytesStart::new("SubSource_name");
         let attrib_element = BytesStart::new("SubSource_attrib");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -2624,7 +2644,7 @@ impl XmlNode for SubSource {
                     } else if qname == attrib_element.name() {
                         source.attrib = read_string(reader);
                     } else if qname != Self::start_bytes().name() {
-                        check_unexpected(&qname, &[]);
+                        forbidden.check(&qname);
                     }
                 }
                 Event::End(e) => {
@@ -2693,6 +2713,7 @@ impl XmlNode for ProtRef {
 
         // attributes that have not been implemented yet
         let forbidden = [processed_tag];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -2710,7 +2731,7 @@ impl XmlNode for ProtRef {
                     } else if name == db_tag.name() {
                         prot.db = read_vec_node(reader, db_tag.to_end()).into();
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -64,7 +64,7 @@ use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use crate::parsing_utils::{next_int, parse_next_string_to};
+use crate::parsing_utils::{read_int, parse_next_string_to};
 use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -1697,7 +1697,7 @@ impl XMLElement for OrgName {
                     parse_next_string_to(&name, &lineage_element, &mut org_name.lineage, reader);
 
                     if name == gcode_element.name() {
-                        org_name.gcode = next_int::<u64>(reader);
+                        org_name.gcode = read_int::<u64>(reader);
                     }
 
                     parse_next_string_to(&name, &div_element, &mut org_name.div, reader)

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -96,8 +96,8 @@ impl XmlNode for FeatId {
         let general_tag = BytesStart::new("Feat-id_general");
 
         let forbidden = [
-            &gibb_tag,
-            &giim_tag
+            gibb_tag,
+            giim_tag
         ];
 
         loop {
@@ -261,18 +261,18 @@ impl XmlNode for SeqFeat {
 
         // list of XML elements that have not been implemented yet
         let forbidden = [
-            &partial_tag,
-            &except_tag,
-            &title_tag,
-            &cit_tag,
-            &exp_ev_tag,
-            &xref_tag,
-            &dbxref_tag,
-            &pseudo_tag,
-            &except_text_tag,
-            &ids_tag,
-            &exts_tag,
-            &support_tag
+            partial_tag,
+            except_tag,
+            title_tag,
+            cit_tag,
+            exp_ev_tag,
+            xref_tag,
+            dbxref_tag,
+            pseudo_tag,
+            except_text_tag,
+            ids_tag,
+            exts_tag,
+            support_tag
         ];
 
         loop {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -263,7 +263,6 @@ impl XmlNode for SeqFeat {
         let forbidden = [
             &partial_tag,
             &except_tag,
-            &comment_tag,
             &title_tag,
             &cit_tag,
             &exp_ev_tag,
@@ -286,6 +285,7 @@ impl XmlNode for SeqFeat {
                     parse_vec_node_to_option(&name, &qual_tag, &mut feat.qual, reader);
                     parse_node_to(&name, &data_tag, &mut feat.data, reader);
                     parse_node_to(&name, &location_tag, &mut feat.location, reader);
+                    parse_string_to(&name, &comment_tag, &mut feat.comment, reader);
 
                     check_unimplemented(&name, &forbidden);
                 }

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,11 +54,11 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{check_unexpected, read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked};
+use crate::parsing::{check_unexpected, read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
-use crate::{XmlNode, XmlVecNode};
+use crate::parsing::{XmlNode, XmlVecNode};
 use bitflags::bitflags;
 use enum_primitive::FromPrimitive;
 use quick_xml::events::{BytesStart, Event};

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,7 +54,7 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{parse_int_to_option, parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node_to_option, read_int, read_node, read_vec_str_unchecked};
+use crate::parsing_utils::{parse_int_to_option, parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node_to_option, read_int, read_node};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
@@ -401,26 +401,26 @@ impl XmlNode for SeqFeatData {
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
         // variant tags
         let gene_tag = BytesStart::new("SeqFeatData_gene");
-        let org_tag = BytesStart::new("SeqFeatData_org");
+        let _org_tag = BytesStart::new("SeqFeatData_org");
         let cdregion_tag = BytesStart::new("SeqFeatData_cdregion");
-        let prot_tag = BytesStart::new("SeqFeatData_prot");
-        let rna_tag = BytesStart::new("SeqFeatData_rna");
-        let pub_tag = BytesStart::new("SeqFeatData_pub");
-        let seq_tag = BytesStart::new("SeqFeatData_seq");
-        let imp_tag = BytesStart::new("SeqFeatData_imp");
-        let region_tag = BytesStart::new("SeqFeatData_region");
-        let bond_tag = BytesStart::new("SeqFeatData_bond");
-        let site_tag = BytesStart::new("SeqFeatData_site");
-        let rsite_tag = BytesStart::new("SeqFeatData_rsite");
-        let user_tag = BytesStart::new("SeqFeatData_user");
-        let txinit_tag = BytesStart::new("SeqFeatData_txinit");
-        let num_tag = BytesStart::new("SeqFeatData_num");
-        let psec_str_tag = BytesStart::new("SeqFeatData_psec-str");
-        let non_std_residue__tag = BytesStart::new("SeqFeatData_non-std-residue");
-        let het_tag = BytesStart::new("SeqFeatData_het");
-        let biosrc_tag = BytesStart::new("SeqFeatData_biosrc");
-        let clone_tag = BytesStart::new("SeqFeatData_clone");
-        let variation_tag = BytesStart::new("SeqFeatData_variation");
+        let _prot_tag = BytesStart::new("SeqFeatData_prot");
+        let _rna_tag = BytesStart::new("SeqFeatData_rna");
+        let _pub_tag = BytesStart::new("SeqFeatData_pub");
+        let _seq_tag = BytesStart::new("SeqFeatData_seq");
+        let _imp_tag = BytesStart::new("SeqFeatData_imp");
+        let _region_tag = BytesStart::new("SeqFeatData_region");
+        let _bond_tag = BytesStart::new("SeqFeatData_bond");
+        let _site_tag = BytesStart::new("SeqFeatData_site");
+        let _rsite_tag = BytesStart::new("SeqFeatData_rsite");
+        let _user_tag = BytesStart::new("SeqFeatData_user");
+        let _txinit_tag = BytesStart::new("SeqFeatData_txinit");
+        let _num_tag = BytesStart::new("SeqFeatData_num");
+        let _psec_str_tag = BytesStart::new("SeqFeatData_psec-str");
+        let _non_std_residue_tag = BytesStart::new("SeqFeatData_non-std-residue");
+        let _het_tag = BytesStart::new("SeqFeatData_het");
+        let _biosrc_tag = BytesStart::new("SeqFeatData_biosrc");
+        let _clone_tag = BytesStart::new("SeqFeatData_clone");
+        let _variation_tag = BytesStart::new("SeqFeatData_variation");
 
         loop {
             match reader.read_event().unwrap() {
@@ -429,6 +429,9 @@ impl XmlNode for SeqFeatData {
 
                     if name == gene_tag.name() {
                         return Self::Gene(read_node(reader).unwrap()).into()
+                    }
+                    if name == cdregion_tag.name() {
+                        return Self::CdRegion(read_node(reader).unwrap()).into()
                     }
                 }
                 Event::End(e) => {
@@ -576,7 +579,7 @@ pub enum CdRegionFrame {
     Three,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 /// Instructions to translate from a nucleic acid to a peptide
 pub struct CdRegion {
@@ -615,6 +618,45 @@ pub struct CdRegion {
     pub stops: Option<u64>,
 }
 
+impl XmlNode for CdRegion {
+    fn start_bytes() -> BytesStart<'static> {
+        BytesStart::new("Cdregion")
+    }
+
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+        let mut cdregion = Self::default();
+
+        // field tags
+        let _orf_tag = BytesStart::new("Cdregion_orf");
+        let _frame_tag = BytesStart::new("Cdregion_frame");
+        let _conflict_tag = BytesStart::new("Cdregion_conflict");
+        let gaps_tag = BytesStart::new("Cdregion_gaps");
+        let mismatch_tag = BytesStart::new("Cdregion_mismatch");
+        let code_tag = BytesStart::new("Cdregion_code");
+        let _code_break_tag = BytesStart::new("Cdregion_code-break");
+        let stops_tag = BytesStart::new("Cdregion_stops");
+
+        loop {
+            match reader.read_event().unwrap() {
+                Event::Start(e) => {
+                    let name = e.name();
+
+                    parse_vec_node_to_option(&name, &code_tag, &mut cdregion.code, reader);
+                    parse_int_to_option(&name, &gaps_tag, &mut cdregion.gaps, reader);
+                    parse_int_to_option(&name, &mismatch_tag, &mut cdregion.mismatch, reader);
+                    parse_int_to_option(&name, &stops_tag, &mut cdregion.stops, reader);
+                }
+                Event::End(e) => {
+                    if Self::is_end(&e) {
+                        return cdregion.into()
+                    }
+                }
+                _ => ()
+            }
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "lowercase")]
 /// Storage type for genetic code data
@@ -646,6 +688,43 @@ pub enum GeneticCodeOpt {
     /// start, indexed to [`crate::asn::NCBIStdAa`]
     SNcbiStdAa(Vec<u8>),
 }
+
+impl XmlNode for GeneticCodeOpt {
+    fn start_bytes() -> BytesStart<'static> {
+        BytesStart::new("Genetic-code_E")
+    }
+
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized {
+        // variant tags
+        let id_tag = BytesStart::new("Genetic-code_E_id");
+        let name_tag = BytesStart::new("Genetic-code_E_name");
+        let ncbieaa_tag = BytesStart::new("Genetic-code_E_ncbieaa");
+        let ncbi8aa_tag = BytesStart::new("Genetic-code_E_ncbi8aa");
+        let ncbistdaa_tag = BytesStart::new("Genetic-code_E_ncbistdaa");
+        let sncbieaa_tag = BytesStart::new("Genetic-code_E_sncbieaa");
+        let sncbi8aa_tag = BytesStart::new("Genetic-code_E_sncbi8aa");
+        let sncbistdaa_tag = BytesStart::new("Genetic-code_E_sncbistdaa");
+
+        loop {
+            match reader.read_event().unwrap() {
+                Event::Start(e) => {
+                    let name = e.name();
+
+                    if name == id_tag.name() {
+                        return Self::Id(read_int(reader).unwrap()).into()
+                    }
+                }
+                Event::End(e) => {
+                    if Self::is_end(&e) {
+                        return None
+                    }
+                }
+                _ => ()
+            }
+        }
+    }
+}
+impl XmlVecNode for GeneticCodeOpt {}
 
 pub type GeneticCode = Vec<GeneticCodeOpt>;
 

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -109,7 +109,7 @@ impl XmlNode for FeatId {
                         return Self::Local(read_node(reader).unwrap()).into();
                     } else if name == general_tag.name() {
                         return Self::General(read_node(reader).unwrap()).into();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &forbidden);
                     }
                 }
@@ -294,7 +294,7 @@ impl XmlNode for SeqFeat {
                         feat.comment = read_string(reader);
                     } else if name == xref_tag.name() {
                         feat.xref = Some(read_vec_node(reader, xref_tag.to_end()));
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &forbidden);
                     }
                 }
@@ -498,7 +498,7 @@ impl XmlNode for SeqFeatData {
                     else if name == prot_tag.name() {
                         return Self::Prot(read_node(reader).unwrap()).into();
                     }
-                    else {
+                    else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &forbidden);
                     }
                 }
@@ -752,7 +752,7 @@ impl XmlNode for CdRegion {
                         cdregion.mismatch = read_int(reader);
                     } else if name == stops_tag.name() {
                         cdregion.stops = read_int(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[])
                     }
                 }
@@ -1933,7 +1933,7 @@ impl XmlNode for GeneRef {
                         gene.db = Some(read_vec_node(reader, db_tag.to_end()));
                     } else if name == locus_tag_tag.name() {
                         gene.locus_tag = read_string(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &forbidden);
                     }
                 }
@@ -2011,7 +2011,7 @@ impl XmlNode for OrgRef {
                         org_ref.orgname = read_node(reader);
                     } else if name == db_element.name() {
                         org_ref.db = Some(read_vec_node(reader, db_element.to_end()))
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -2141,7 +2141,7 @@ impl XmlNode for OrgName {
                         org_name.name = read_node(reader);
                     } else if name == mod_element.name() {
                         org_name.r#mod = Some(read_vec_node(reader, mod_element.to_end()));
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -2277,7 +2277,7 @@ impl XmlNode for OrgMod {
                         r#mod.subname = read_string(reader).unwrap();
                     } else if name == attrib_element.name() {
                         r#mod.attrib = read_string(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -2329,7 +2329,7 @@ impl XmlNode for BinomialOrgName {
                         binomial.species = read_string(reader);
                     } else if name == subspecies_element.name() {
                         binomial.subspecies = read_string(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -2479,7 +2479,7 @@ impl XmlNode for BioSource {
                         source.org = read_node(reader).unwrap();
                     } else if name == subtype_element.name() {
                         source.subtype = Some(read_vec_node(reader, subtype_element.to_end()))
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -2623,7 +2623,7 @@ impl XmlNode for SubSource {
                         source.name = read_string(reader).unwrap();
                     } else if qname == attrib_element.name() {
                         source.attrib = read_string(reader);
-                    } else {
+                    } else if qname != Self::start_bytes().name() {
                         check_unexpected(&qname, &[]);
                     }
                 }
@@ -2709,7 +2709,7 @@ impl XmlNode for ProtRef {
                         prot.activity = read_vec_str_unchecked(reader, &activity_tag.to_end()).into();
                     } else if name == db_tag.name() {
                         prot.db = read_vec_node(reader, db_tag.to_end()).into();
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &forbidden);
                     }
                 }

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -267,7 +267,6 @@ impl XmlNode for SeqFeat {
             &product_tag,
             &qual_tag,
             &title_tag,
-            &ext_tag,
             &cit_tag,
             &exp_ev_tag,
             &xref_tag,
@@ -284,6 +283,7 @@ impl XmlNode for SeqFeat {
                 Event::Start(e) => {
                     let name = e.name();
                     parse_node_to_option(&name, &id_tag, &mut feat.id, reader);
+                    parse_node_to_option(&name, &ext_tag, &mut feat.ext, reader);
                     parse_node_to(&name, &data_tag, &mut feat.data, reader);
                     parse_node_to(&name, &location_tag, &mut feat.location, reader);
 

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,7 +54,7 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing_utils::{parse_int_to_option, parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node_to_option, read_int, read_node};
+use crate::parsing_utils::{check_unimplemented, parse_int_to_option, parse_node_to, parse_node_to_option, parse_string_to, parse_vec_node_to_option, read_int, read_node};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
@@ -249,6 +249,26 @@ impl XmlNode for SeqFeat {
         let ids_tag = BytesStart::new("Seq-feat_ids");
         let exts_tag = BytesStart::new("Seq-feat_exts");
         let support_tag = BytesStart::new("Seq-feat_support");
+
+        // list of XML elements that have not been implemented yet
+        let forbidden = [
+            &partial_tag,
+            &except_tag,
+            &comment_tag,
+            &product_tag,
+            &qual_tag,
+            &title_tag,
+            &ext_tag,
+            &cit_tag,
+            &exp_ev_tag,
+            &xref_tag,
+            &dbxref_tag,
+            &pseudo_tag,
+            &except_text_tag,
+            &ids_tag,
+            &exts_tag,
+            &support_tag
+        ];
 
         loop {
             match reader.read_event().unwrap() {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -61,7 +61,7 @@ use crate::parsing_utils::{
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use bitflags::bitflags;
 use enum_primitive::FromPrimitive;
 use quick_xml::events::{BytesStart, Event};
@@ -1548,7 +1548,7 @@ pub struct OrgRef {
     pub orgname: Option<OrgName>,
 }
 
-impl XMLElement for OrgRef {
+impl XmlNode for OrgRef {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Org-ref")
     }
@@ -1599,7 +1599,7 @@ pub enum OrgNameChoice {
     Partial(PartialOrgName),
 }
 
-impl XMLElement for OrgNameChoice {
+impl XmlNode for OrgNameChoice {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("OrgName_name")
     }
@@ -1660,7 +1660,7 @@ pub struct OrgName {
     pub pgcode: Option<u64>,
 }
 
-impl XMLElement for OrgName {
+impl XmlNode for OrgName {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("OrgName")
     }
@@ -1774,7 +1774,7 @@ impl Default for OrgModSubType {
     }
 }
 
-impl XMLElement for OrgModSubType {
+impl XmlNode for OrgModSubType {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("OrgMod_subtype")
     }
@@ -1796,7 +1796,7 @@ pub struct OrgMod {
     pub attrib: Option<String>,
 }
 
-impl XMLElement for OrgMod {
+impl XmlNode for OrgMod {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("OrgMod")
     }
@@ -1830,7 +1830,7 @@ impl XMLElement for OrgMod {
         }
     }
 }
-impl XMLElementVec for OrgMod {}
+impl XmlVecNode for OrgMod {}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct BinomialOrgName {
@@ -1842,7 +1842,7 @@ pub struct BinomialOrgName {
     pub subspecies: Option<String>,
 }
 
-impl XMLElement for BinomialOrgName {
+impl XmlNode for BinomialOrgName {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("BinomialOrgName")
     }
@@ -1935,7 +1935,7 @@ enum_from_primitive! {
     }
 }
 
-impl XMLElement for BioSourceGenome {
+impl XmlNode for BioSourceGenome {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("BioSource_genome")
     }
@@ -1988,7 +1988,7 @@ pub struct BioSource {
     pub pcr_primers: Option<PCRReationSet>,
 }
 
-impl XMLElement for BioSource {
+impl XmlNode for BioSource {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("BioSource")
     }
@@ -2108,7 +2108,7 @@ impl Default for SubSourceSubType {
     }
 }
 
-impl XMLElement for SubSourceSubType {
+impl XmlNode for SubSourceSubType {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("SubSource_subtype")
     }
@@ -2127,7 +2127,7 @@ pub struct SubSource {
     pub attrib: Option<String>,
 }
 
-impl XMLElement for SubSource {
+impl XmlNode for SubSource {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("SubSource")
     }
@@ -2158,7 +2158,7 @@ impl XMLElement for SubSource {
         }
     }
 }
-impl XMLElementVec for SubSource {}
+impl XmlVecNode for SubSource {}
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug, Default)]
 #[repr(u8)]

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -54,7 +54,7 @@
 
 use crate::biblio::{PubMedId, DOI};
 use crate::general::{DbTag, IntFuzz, ObjectId, UserObject};
-use crate::parsing::{read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked, UnexpectedTags};
+use crate::parsing::{read_vec_node, read_int, read_node, read_string, read_vec_str_unchecked, UnexpectedTags, read_bool_attribute};
 use crate::r#pub::PubSet;
 use crate::seq::{Heterogen, Numbering, PubDesc, SeqLiteral};
 use crate::seqloc::{GiimportId, SeqId, SeqLoc};
@@ -268,7 +268,6 @@ impl XmlNode for SeqFeat {
             cit_tag,
             exp_ev_tag,
             dbxref_tag,
-            pseudo_tag,
             except_text_tag,
             ids_tag,
             exts_tag,
@@ -298,6 +297,11 @@ impl XmlNode for SeqFeat {
                         feat.xref = Some(read_vec_node(reader, xref_tag.to_end()));
                     } else if name != Self::start_bytes().name() {
                         forbidden.check(&name);
+                    }
+                }
+                Event::Empty(e) => {
+                    if e.name() == pseudo_tag.name() {
+                        feat.pseudo = read_bool_attribute(&e);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -1997,7 +1997,7 @@ impl XmlNode for BioSource {
         let mut source = Self::default();
 
         let genome_element = BytesStart::new("BioSource_genome");
-        let origin_element = BytesStart::new("BioSource_origin");
+        let _origin_element = BytesStart::new("BioSource_origin");
         let org_element = BytesStart::new("BioSource_org");
         let subtype_element = BytesStart::new("BioSource_subtype");
 

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -276,6 +276,9 @@ impl XmlNode for SeqFeat {
                     let name = e.name();
                     parse_node_to_option(&name, &id_tag, &mut feat.id, reader);
                     parse_node_to(&name, &data_tag, &mut feat.data, reader);
+                    parse_node_to(&name, &location_tag, &mut feat.location, reader);
+
+                    check_unimplemented(&name, &forbidden);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -8,9 +8,9 @@
 
 use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
-use crate::parsing_utils::{check_unexpected, read_attributes, read_int, read_node, read_string};
+use crate::parsing::{check_unexpected, read_attributes, read_int, read_node, read_string};
 use crate::seqfeat::FeatId;
-use crate::{XmlNode, XmlVecNode, XmlValue};
+use crate::parsing::{XmlNode, XmlVecNode, XmlValue};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -144,7 +144,7 @@ impl XmlNode for TextseqId {
                         id.release = read_string(reader);
                     } else if name == version_element.name() {
                         id.version = read_int(reader);
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }
@@ -261,9 +261,9 @@ impl XmlNode for SeqLoc {
                         return Self::Int(read_node(reader).unwrap()).into()
                     } else if name == whole_variant.name() {
                         return Self::Whole(read_node(reader).unwrap()).into()
-                    } else {
-                            check_unexpected(&name, &forbidden);
-                        }
+                    } else if name != Self::start_bytes().name() {
+                        check_unexpected(&name, &forbidden);
+                    }
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -8,7 +8,7 @@
 
 use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
-use crate::parsing::{read_attributes, read_int, read_node, read_string, UnexpectedTags};
+use crate::parsing::{attribute_value, read_attributes, read_int, read_node, read_string, UnexpectedTags};
 use crate::seqfeat::FeatId;
 use crate::parsing::{XmlNode, XmlVecNode, XmlValue};
 use quick_xml::events::{BytesStart, Event};
@@ -385,31 +385,18 @@ impl XmlValue for NaStrand {
     }
 
     fn from_attributes(attributes: Attributes) -> Option<Self> {
-        let value = BytesStart::new("value");
-        for attribute in attributes {
-            if let Ok(attr) = attribute {
-                if attr.key == value.name() {
-                    let _inner = attr.unescape_value().unwrap().to_string();
-                    let inner = _inner.get(2.._inner.len()-2).unwrap();
-                    if inner == "unknown" {
-                        return Self::Unknown.into()
-                    }
-                    if inner == "plus" {
-                        return Self::Plus.into()
-                    }
-                    if inner == "minus" {
-                        return Self::Minus.into()
-                    }
-                    if inner == "both" {
-                        return Self::Both.into()
-                    }
-                    if inner == "both-rev" {
-                        return Self::BothRev.into()
-                    }
-                }
+        if let Some(attributes) = attribute_value(attributes) {
+            match attributes.as_str() {
+                "unknown" => Self::Unknown.into(),
+                "plus" => Self::Plus.into(),
+                "minus" => Self::Minus.into(),
+                "both" => Self::Both.into(),
+                "both-rev" => Self::BothRev.into(),
+                _ => None
             }
+        } else {
+            None
         }
-        return None
     }
 }
 

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -8,16 +8,16 @@
 
 use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
+use crate::parsing_utils::{parse_int_to_option, parse_string_to, read_int, read_node};
 use crate::seqfeat::FeatId;
-use serde::{Serialize, Deserialize};
-use serde_repr::{Serialize_repr, Deserialize_repr};
+use crate::{XMLElement, XMLElementVec};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use crate::{XMLElement, XMLElementVec};
-use crate::parsing_utils::{parse_int_to_option, parse_string_to, read_int, read_node};
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SeqId {
     Local(ObjectId),
     /// GenInfo backbone sequence id
@@ -64,7 +64,7 @@ pub enum SeqId {
     /// internal NCBI genome pipeline
     Gpipe(TextseqId),
 
-    #[serde(rename="named-annot-track")]
+    #[serde(rename = "named-annot-track")]
     /// internal named annotation
     NamedAnnotTrack(TextseqId),
 }
@@ -87,9 +87,8 @@ impl XMLElement for SeqId {
                 }
                 if e.name() == general_element.name() {
                     return SeqId::General(read_node(reader).unwrap()).into();
-                }
-                else if e.name() == gi_element.name() {
-                    return SeqId::Gi(read_int(reader).unwrap()).into()
+                } else if e.name() == gi_element.name() {
+                    return SeqId::Gi(read_int(reader).unwrap()).into();
                 }
             }
         }
@@ -141,10 +140,10 @@ impl XMLElement for TextseqId {
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {
-                        return id.into()
+                        return id.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -158,7 +157,7 @@ pub struct GiimportId {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct PDBSeqId {
     pub mol: PDBMolId,
     pub rel: Option<Date>,
@@ -169,7 +168,7 @@ pub struct PDBSeqId {
 pub type PDBMolId = String;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Defines a location on a [`BioSeq`].
 ///
 /// Class hierarchy makes it possible to use the same type in multiple contexts.
@@ -206,7 +205,7 @@ pub enum SeqLoc {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqInterval {
     pub from: i64,
     pub to: i64,
@@ -227,7 +226,7 @@ pub struct SeqPoint {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct PackedSeqPnt {
     pub strand: Option<NaStrand>,
     pub id: SeqId,

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -215,6 +215,19 @@ pub struct SeqInterval {
     pub fuzz_to: Option<IntFuzz>,
 }
 
+impl Default for SeqInterval {
+    fn default() -> Self {
+        Self {
+            from: 0,
+            to: 0,
+            strand: None,
+            id: SeqId::Other(TextseqId::default()),
+            fuzz_from: None,
+            fuzz_to: None
+        }
+    }
+}
+
 pub type PackedSeqInt = Vec<SeqInterval>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -10,7 +10,7 @@ use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
 use crate::parsing_utils::{parse_int_to_option, parse_string_to, read_int, read_node};
 use crate::seqfeat::FeatId;
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ pub enum SeqId {
     NamedAnnotTrack(TextseqId),
 }
 
-impl XMLElement for SeqId {
+impl XmlNode for SeqId {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seq-id")
     }
@@ -94,7 +94,7 @@ impl XMLElement for SeqId {
         }
     }
 }
-impl XMLElementVec for SeqId {}
+impl XmlVecNode for SeqId {}
 
 pub type SeqIdSet = Vec<SeqId>;
 
@@ -115,7 +115,7 @@ pub struct TextseqId {
     pub version: Option<u64>,
 }
 
-impl XMLElement for TextseqId {
+impl XmlNode for TextseqId {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Textseq-id")
     }

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -8,7 +8,7 @@
 
 use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
-use crate::parsing::{check_unexpected, read_attributes, read_int, read_node, read_string};
+use crate::parsing::{read_attributes, read_int, read_node, read_string, UnexpectedTags};
 use crate::seqfeat::FeatId;
 use crate::parsing::{XmlNode, XmlVecNode, XmlValue};
 use quick_xml::events::{BytesStart, Event};
@@ -131,6 +131,8 @@ impl XmlNode for TextseqId {
         let release_element = BytesStart::new("Textseq-id_release");
         let version_element = BytesStart::new("Textseq-id_version");
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -145,7 +147,7 @@ impl XmlNode for TextseqId {
                     } else if name == version_element.name() {
                         id.version = read_int(reader);
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {
@@ -251,6 +253,7 @@ impl XmlNode for SeqLoc {
             bond_variant,
             feat_variant
         ];
+        let forbidden = UnexpectedTags(&forbidden);
 
         loop {
             match reader.read_event().unwrap() {
@@ -262,7 +265,7 @@ impl XmlNode for SeqLoc {
                     } else if name == whole_variant.name() {
                         return Self::Whole(read_node(reader).unwrap()).into()
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &forbidden);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -285,7 +285,7 @@ impl XmlNode for SeqInterval {
                     parse_node_to(&name, &id_element, &mut interval.id, reader);
                 }
                 Event::Empty(e) => {
-                    parse_attribute_to_option(&e, &NaStrand::start_bytes(), &mut interval.strand, reader);
+                    parse_attribute_to_option(&e, &NaStrand::start_bytes(), &mut interval.strand);
                 }
                 Event::End(e) => {
                     if Self::is_end(&e) {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -74,7 +74,7 @@ impl XMLElement for SeqId {
         BytesStart::new("Seq-id")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         // variants
         let other = BytesStart::new("Seq-id_other");
         let general = BytesStart::new("Seq-id_general");
@@ -83,10 +83,10 @@ impl XMLElement for SeqId {
         loop {
             if let Event::Start(e) = reader.read_event().unwrap() {
                 if e.name() == other.name() {
-                    return SeqId::Other(TextseqId::from_reader(reader)).into();
+                    return SeqId::Other(TextseqId::from_reader(reader).unwrap()).into();
                 }
                 else if e.name() == general.name() {
-                    return SeqId::General(DbTag::from_reader(reader)).into();
+                    return SeqId::General(DbTag::from_reader(reader).unwrap()).into();
                 }
                 else if e.name() == gi.name() {
                     if let Event::Text(text) = reader.read_event().unwrap() {
@@ -124,7 +124,7 @@ impl XMLElement for TextseqId {
         BytesStart::new("Textseq-id")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         let mut name = None;
         let mut accession = None;
         let mut release = None;
@@ -173,7 +173,7 @@ impl XMLElement for TextseqId {
             accession,
             release,
             version
-        }
+        }.into()
     }
 }
 

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -207,6 +207,13 @@ pub enum SeqLoc {
     Feat(FeatId),
 }
 
+impl SeqLoc {
+    /// default not originally in spec
+    pub fn default() -> Self {
+        Self::Null
+    }
+}
+
 impl XmlNode for SeqLoc {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seq-loc")

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -8,7 +8,7 @@
 
 use crate::biblio::IdPat;
 use crate::general::{Date, DbTag, IntFuzz, ObjectId};
-use crate::parsing_utils::{check_unimplemented, read_attributes, read_int, read_node, read_string};
+use crate::parsing_utils::{check_unexpected, read_attributes, read_int, read_node, read_string};
 use crate::seqfeat::FeatId;
 use crate::{XmlNode, XmlVecNode, XmlValue};
 use quick_xml::events::{BytesStart, Event};
@@ -145,7 +145,7 @@ impl XmlNode for TextseqId {
                     } else if name == version_element.name() {
                         id.version = read_int(reader);
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {
@@ -262,7 +262,7 @@ impl XmlNode for SeqLoc {
                     } else if name == whole_variant.name() {
                         return Self::Whole(read_node(reader).unwrap()).into()
                     } else {
-                            check_unimplemented(&name, &forbidden);
+                            check_unexpected(&name, &forbidden);
                         }
                 }
                 Event::End(e) => {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -234,15 +234,15 @@ impl XmlNode for SeqLoc {
         let feat_variant = BytesStart::new("Seq-loc_feat");
 
         let forbidden = [
-            &null_variant,
-            &empty_variant,
-            &packed_int_variant,
-            &pnt_variant,
-            &packed_pnt_variant,
-            &mix_variant,
-            &equiv_variant,
-            &bond_variant,
-            &feat_variant
+            null_variant,
+            empty_variant,
+            packed_int_variant,
+            pnt_variant,
+            packed_pnt_variant,
+            mix_variant,
+            equiv_variant,
+            bond_variant,
+            feat_variant
         ];
 
         loop {

--- a/src/asn/seqloc.rs
+++ b/src/asn/seqloc.rs
@@ -14,7 +14,7 @@ use serde::{Serialize, Deserialize};
 use serde_repr::{Serialize_repr, Deserialize_repr};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all="lowercase")]
@@ -99,6 +99,7 @@ impl XMLElement for SeqId {
         }
     }
 }
+impl XMLElementVec for SeqId {}
 
 pub type SeqIdSet = Vec<SeqId>;
 

--- a/src/asn/seqres.rs
+++ b/src/asn/seqres.rs
@@ -3,10 +3,10 @@
 //! Adapted from ["seqres.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seqres/seqres.asn)
 
 use crate::seqloc::SeqLoc;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SeqGraphChoice {
     Real(RealGraph),
     Int(IntGraph),
@@ -14,7 +14,7 @@ pub enum SeqGraphChoice {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// For values mapped by residue or range to sequence
 pub struct SeqGraph {
     pub title: Option<String>,
@@ -39,7 +39,7 @@ pub struct SeqGraph {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct Graph<T> {
     /// top of graph
     pub max: T,

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -4,7 +4,7 @@
 //! from the NCBI C++ Toolkit
 
 use crate::general::{Date, DbTag, ObjectId};
-use crate::parsing_utils::{parse_vec_node_to, read_node};
+use crate::parsing_utils::{check_unimplemented, read_vec_node, read_node};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
@@ -125,7 +125,11 @@ impl XmlNode for BioSeqSet {
                 Event::Start(e) => {
                     let name = e.name();
 
-                    parse_vec_node_to(&name, &seq_set_element, &mut set.seq_set, reader);
+                    if name == seq_set_element.name() {
+                        set.seq_set = read_vec_node(reader, seq_set_element.to_end());
+                    } else {
+                        check_unimplemented(&name, &[]);
+                    }
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -6,7 +6,7 @@
 use crate::general::{Date, DbTag, ObjectId};
 use crate::parsing_utils::{parse_vec_node_to, read_node};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
-use crate::{XMLElement, XMLElementVec};
+use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
@@ -110,7 +110,7 @@ pub struct BioSeqSet {
     pub annot: Option<Vec<SeqAnnot>>,
 }
 
-impl XMLElement for BioSeqSet {
+impl XmlNode for BioSeqSet {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Bioseq-set")
     }
@@ -145,7 +145,7 @@ pub enum SeqEntry {
     Set(BioSeqSet),
 }
 
-impl XMLElement for SeqEntry {
+impl XmlNode for SeqEntry {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seq-entry")
     }
@@ -177,4 +177,4 @@ impl XMLElement for SeqEntry {
         }
     }
 }
-impl XMLElementVec for SeqEntry {}
+impl XmlVecNode for SeqEntry {}

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -120,7 +120,6 @@ impl XmlNode for BioSeqSet {
 
         let mut set = Self::default();
 
-        println!("Starting to parse BioSeqSet");
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -153,7 +152,6 @@ impl XmlNode for SeqEntry {
         let seq = BytesStart::new("Seq-entry_seq");
         let set = BytesStart::new("Seq-entry_set");
 
-        println!("Beginning to parse Seq-entry");
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -4,7 +4,7 @@
 //! from the NCBI C++ Toolkit
 
 use crate::general::{Date, DbTag, ObjectId};
-use crate::parsing::{check_unexpected, read_vec_node, read_node};
+use crate::parsing::{read_vec_node, read_node, UnexpectedTags};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
 use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
@@ -120,6 +120,8 @@ impl XmlNode for BioSeqSet {
 
         let mut set = Self::default();
 
+        let forbidden = UnexpectedTags(&[]);
+
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
@@ -128,7 +130,7 @@ impl XmlNode for BioSeqSet {
                     if name == seq_set_element.name() {
                         set.seq_set = read_vec_node(reader, seq_set_element.to_end());
                     } else if name != Self::start_bytes().name() {
-                        check_unexpected(&name, &[]);
+                        forbidden.check(&name);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -4,7 +4,7 @@
 //! from the NCBI C++ Toolkit
 
 use crate::general::{Date, DbTag, ObjectId};
-use crate::parsing_utils::{check_unimplemented, read_vec_node, read_node};
+use crate::parsing_utils::{check_unexpected, read_vec_node, read_node};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
 use crate::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
@@ -128,7 +128,7 @@ impl XmlNode for BioSeqSet {
                     if name == seq_set_element.name() {
                         set.seq_set = read_vec_node(reader, seq_set_element.to_end());
                     } else {
-                        check_unimplemented(&name, &[]);
+                        check_unexpected(&name, &[]);
                     }
                 }
                 Event::End(e) => {

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -114,7 +114,7 @@ impl XMLElement for BioSeqSet {
         BytesStart::new("Bioseq-set")
     }
 
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         let seq_set_element = BytesStart::new("Bioseq-set_seq-set");
 
         let mut id = None;
@@ -155,7 +155,7 @@ impl XMLElement for BioSeqSet {
             descr,
             seq_set,
             annot,
-        }
+        }.into()
     }
 }
 
@@ -169,7 +169,7 @@ impl XMLElement for SeqEntry {
     fn start_bytes() -> BytesStart<'static> {
         BytesStart::new("Seq-entry")
     }
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self {
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> {
         let seq = BytesStart::new("Seq-entry_seq");
         let set = BytesStart::new("Seq-entry_set");
 
@@ -181,10 +181,10 @@ impl XMLElement for SeqEntry {
                 Event::Start(e) => {
                     println!("Got here");
                     if e.name() == seq.name() {
-                        entry = Self::Seq(BioSeq::from_reader(reader)).into();
+                        entry = Self::Seq(BioSeq::from_reader(reader).unwrap()).into();
                     }
                     else if e.name() == set.name() {
-                        entry = Self::Set(BioSeqSet::from_reader(reader)).into();
+                        entry = Self::Set(BioSeqSet::from_reader(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
@@ -198,6 +198,6 @@ impl XMLElement for SeqEntry {
         }
         println!("Finished parsing Seq-entry");
 
-        entry.unwrap()
+        entry
     }
 }

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -9,7 +9,7 @@ use crate::general::{Date, DbTag, ObjectId};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
 use serde::{Serialize, Deserialize};
 use serde_repr::{Serialize_repr, Deserialize_repr};
-use crate::XMLElement;
+use crate::{XMLElement, XMLElementVec};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug, Default)]
 #[repr(u8)]
@@ -201,3 +201,4 @@ impl XMLElement for SeqEntry {
         entry
     }
 }
+impl XMLElementVec for SeqEntry {}

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -4,9 +4,9 @@
 //! from the NCBI C++ Toolkit
 
 use crate::general::{Date, DbTag, ObjectId};
-use crate::parsing_utils::{check_unexpected, read_vec_node, read_node};
+use crate::parsing::{check_unexpected, read_vec_node, read_node};
 use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
-use crate::{XmlNode, XmlVecNode};
+use crate::parsing::{XmlNode, XmlVecNode};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -127,7 +127,7 @@ impl XmlNode for BioSeqSet {
 
                     if name == seq_set_element.name() {
                         set.seq_set = read_vec_node(reader, seq_set_element.to_end());
-                    } else {
+                    } else if name != Self::start_bytes().name() {
                         check_unexpected(&name, &[]);
                     }
                 }

--- a/src/asn/seqset.rs
+++ b/src/asn/seqset.rs
@@ -3,14 +3,14 @@
 //! Adapted from ["seqset.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/CPP_DOC/lxr/source/src/objects/seqset/seqset.asn)
 //! from the NCBI C++ Toolkit
 
+use crate::general::{Date, DbTag, ObjectId};
+use crate::parsing_utils::{parse_vec_node_to, read_node};
+use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
+use crate::{XMLElement, XMLElementVec};
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use crate::general::{Date, DbTag, ObjectId};
-use crate::seq::{BioSeq, SeqAnnot, SeqDescr};
-use serde::{Serialize, Deserialize};
-use serde_repr::{Serialize_repr, Deserialize_repr};
-use crate::{XMLElement, XMLElementVec};
-use crate::parsing_utils::{parse_vec_node_to, read_node};
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug, Default)]
 #[repr(u8)]
@@ -130,10 +130,10 @@ impl XMLElement for BioSeqSet {
                 }
                 Event::End(e) => {
                     if e.name() == Self::start_bytes().to_end().name() {
-                        return set.into()
+                        return set.into();
                     }
                 }
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -160,22 +160,16 @@ impl XMLElement for SeqEntry {
                     let name = e.name();
 
                     if name == seq.name() {
-                        return Self::Seq(
-                            read_node(reader)
-                                .unwrap())
-                            .into();
+                        return Self::Seq(read_node(reader).unwrap()).into();
                     }
                     if name == set.name() {
-                        return Self::Set(
-                            read_node(reader)
-                                .unwrap())
-                            .into();
+                        return Self::Set(read_node(reader).unwrap()).into();
                     }
                 }
                 Event::End(e) => {
                     // correctly escape "Seq-entry"
                     if Self::is_end(&e) {
-                        return None
+                        return None;
                     }
                 }
                 _ => (),

--- a/src/asn/seqtable.rs
+++ b/src/asn/seqtable.rs
@@ -2,9 +2,9 @@
 //!
 //! Adapted from ["seqtable.asn"](https://www.ncbi.nlm.nih.gov/IEB/ToolBox/C_DOC/lxr/source/asn/seqtable.asn)
 
-use crate::seqloc::{SeqId, SeqLoc, SeqInterval};
-use serde::{Serialize, Deserialize};
-use serde_repr::{Serialize_repr, Deserialize_repr};
+use crate::seqloc::{SeqId, SeqInterval, SeqLoc};
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Serialize_repr, Deserialize_repr, PartialEq, Debug)]
 #[repr(u8)]
@@ -53,7 +53,7 @@ pub enum ColumnInfoFieldId {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 /// Unsure on how this object is used
 ///
 /// Nor do I know of any examples of the use of `field_name`. It *could*
@@ -146,7 +146,7 @@ pub struct BVectorData {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum SeqTableMultiData {
     /// a set of 4-byte integers, one per row
     Int(Vec<u32>),
@@ -189,21 +189,21 @@ pub enum SeqTableMultiData {
     ///     see include/util/bitset/bm.h
     BitVector(BVectorData),
 
-    #[serde(rename="int1")]
+    #[serde(rename = "int1")]
     /// a set of signed 1-byte integers encoded as sequential octets
     Int1(Vec<u8>),
 
-    #[serde(rename="int2")]
+    #[serde(rename = "int2")]
     /// a set of signed 2-byte integers
     Int2(Vec<u16>),
 
-    #[serde(rename="int3")]
+    #[serde(rename = "int3")]
     /// a set of signed 8-byte integers
     Int8(Vec<u64>),
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum SeqTableSingleData {
     Int(u64),
     Real(f64),
@@ -217,7 +217,7 @@ pub enum SeqTableSingleData {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum SeqTableSparseIndex {
     /// Indexes of rows with values
     Indexes(Vec<u64>),
@@ -236,7 +236,7 @@ pub enum SeqTableSparseIndex {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqTableColumn {
     /// column description or reference to previously defined info
     pub header: SeqTableColumnInfo,
@@ -255,7 +255,7 @@ pub struct SeqTableColumn {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all="kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct SeqTable {
     /// type of features in this table
     ///

--- a/src/element.rs
+++ b/src/element.rs
@@ -5,6 +5,10 @@ pub trait XMLElement {
     fn start_bytes() -> BytesStart<'static>;
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized;
 
+    fn is_end(element: &BytesEnd) -> bool {
+        element.name() == Self::start_bytes().name()
+    }
+
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
         E: Into<Option<BytesEnd<'a>>>,
@@ -27,6 +31,9 @@ pub trait XMLElement {
                     if e.name() == end.name() {
                         break;
                     }
+                }
+                Event::Eof => {
+                    break;
                 }
                 _ => (),
             }

--- a/src/element.rs
+++ b/src/element.rs
@@ -2,18 +2,54 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
 
-/// Parses [`Event::Empty`] values
+/// Handles parsing of simple data from [`Event::Empty`] values
 ///
-/// Differs from [`XmlNode`] in that
-/// [`Self::from_attributes`] accepts [`Attributes`],
-/// whereas [`XmlNode::from_reader()`] accepts an [`XMLReader`]
+/// An empty value is used in Entrez output to typically to enclose boolean values.
+/// An empty tag named `TagName` is denoted by `<TagName value="{value}" />`, where
+/// the enclosed value is `{value}` denoted by the "value" attribute name. In the case of
+/// boolean values, `true` is denoted by "true"; `false` by "false".
+///
+/// [`XmlValue`] differs from [`XmlNode`] in that it's main reader function
+/// [`Self::from_attributes`] accepts [`Attributes`], whereas [`XmlNode::from_reader()`]
+/// parses raw bytes from [`XMLReader`].
 pub trait XmlValue {
     fn start_bytes() -> BytesStart<'static>;
     fn from_attributes(bytes: Attributes) -> Option<Self> where Self: Sized;
 }
 
+/// Contains methods for parsing XML data
+///
+/// A struct or enum that implements [`XmlNode`] is able to be parsed by XML data.
+///
+/// ## How ASN.1 types should be parsed
+///
+/// Two types of values parsed by `XmlNode`: enums and structs.
+/// Both field/variant name/value have tags to separate between the field/variant and the
+/// enclosed value. Decision what should be parsed is denoted by [`Self::start_bytes()`].
 pub trait XmlNode {
+
+    /// Return starting element
+    ///
+    /// This function should be used my implementations of [`XmlNode::from_reader()`]
+    /// to signify the starting and stopping of parsed data and to distinguish between
+    /// other [`XmlNode`]'s.
+    ///
+    /// Element tags are all hardcoded and do not yet take into account namespaces. There
+    /// is no simple, idiomatic way to gracefully implement this. Therefore, changing
+    /// this is not planned on being implemented especially since the ASN.1 data format
+    /// is not likely to change much.
     fn start_bytes() -> BytesStart<'static>;
+
+    /// Process the XML data as `Self`
+    ///
+    /// This function is called once [`Self::start_bytes()`] has been encountered,
+    /// so implementations should assume that the data is [`Self`] therefore
+    /// field or variant values must begin being parsed.
+    ///
+    /// Parsed struct (or `None` in the case of an enum) should be returned upon
+    /// encountering a closing tag derived from [`Self::start_bytes()`]. This halts
+    /// consumption of data from `reader` so that remaining data can be consumed by
+    /// subsequent parsing functions.
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
     where
         Self: Sized;
@@ -23,7 +59,14 @@ pub trait XmlNode {
     }
 }
 
+/// An element with the [`XmlVecNode`] trait is able to be parsed into a [`Vec`].
 pub trait XmlVecNode: XmlNode {
+
+    /// Parse XML data as multiple [`XmlNode`] objects contained by [`Vec`]
+    ///
+    /// [`Self::vec_from_reader()`] (or the helper function [`crate::parsing_utils::read_vec_node()`])
+    /// should be used to parse multiple [`XmlNode`] objects into a vector at once. Using these helper
+    /// functions reduces errors in parsing implementation.
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
         E: Into<Option<BytesEnd<'a>>>,

--- a/src/element.rs
+++ b/src/element.rs
@@ -3,7 +3,9 @@ use quick_xml::Reader;
 
 pub trait XMLElement {
     fn start_bytes() -> BytesStart<'static>;
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized;
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
+    where
+        Self: Sized;
 
     fn is_end(element: &BytesEnd) -> bool {
         element.name() == Self::start_bytes().name()
@@ -14,7 +16,7 @@ pub trait XMLElementVec: XMLElement {
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
         E: Into<Option<BytesEnd<'a>>>,
-        Self: Sized
+        Self: Sized,
     {
         let binding = Self::start_bytes();
         let end = end.into().unwrap_or(binding.to_end());

--- a/src/element.rs
+++ b/src/element.rs
@@ -3,7 +3,7 @@ use quick_xml::Reader;
 
 pub trait XMLElement {
     fn start_bytes() -> BytesStart<'static>;
-    fn from_reader(reader: &mut Reader<&[u8]>) -> Self;
+    fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self> where Self: Sized;
 
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
@@ -12,13 +12,15 @@ pub trait XMLElement {
     {
         let binding = Self::start_bytes();
         let end = end.into().unwrap_or(binding.to_end());
-        let mut ids = Vec::new();
+        let mut items = Vec::new();
 
         loop {
             match reader.read_event().unwrap() {
                 Event::Start(e) => {
                     if e.name() == Self::start_bytes().name() {
-                        ids.push(Self::from_reader(reader));
+                        if let Some(val) = Self::from_reader(reader) {
+                            items.push(val);
+                        }
                     }
                 }
                 Event::End(e) => {
@@ -30,6 +32,6 @@ pub trait XMLElement {
             }
         }
 
-        ids
+        items
     }
 }

--- a/src/element.rs
+++ b/src/element.rs
@@ -4,15 +4,15 @@ use quick_xml::Reader;
 
 /// Parses [`Event::Empty`] values
 ///
-/// Differs from [`XMLElement`] in that
+/// Differs from [`XmlNode`] in that
 /// [`Self::from_attributes`] accepts [`Attributes`],
-/// whereas [`XMLElement::from_reader()`] accepts an [`XMLReader`]
+/// whereas [`XmlNode::from_reader()`] accepts an [`XMLReader`]
 pub trait XmlValue {
     fn start_bytes() -> BytesStart<'static>;
     fn from_attributes(bytes: Attributes) -> Option<Self> where Self: Sized;
 }
 
-pub trait XMLElement {
+pub trait XmlNode {
     fn start_bytes() -> BytesStart<'static>;
     fn from_reader(reader: &mut Reader<&[u8]>) -> Option<Self>
     where
@@ -23,7 +23,7 @@ pub trait XMLElement {
     }
 }
 
-pub trait XMLElementVec: XMLElement {
+pub trait XmlVecNode: XmlNode {
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
         E: Into<Option<BytesEnd<'a>>>,

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,5 +1,16 @@
 use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::events::attributes::Attributes;
 use quick_xml::Reader;
+
+/// Parses [`Event::Empty`] values
+///
+/// Differs from [`XMLElement`] in that
+/// [`Self::from_attributes`] accepts [`Attributes`],
+/// whereas [`XMLElement::from_reader()`] accepts an [`XMLReader`]
+pub trait XmlValue {
+    fn start_bytes() -> BytesStart<'static>;
+    fn from_attributes(bytes: Attributes) -> Option<Self> where Self: Sized;
+}
 
 pub trait XMLElement {
     fn start_bytes() -> BytesStart<'static>;

--- a/src/element.rs
+++ b/src/element.rs
@@ -8,7 +8,9 @@ pub trait XMLElement {
     fn is_end(element: &BytesEnd) -> bool {
         element.name() == Self::start_bytes().name()
     }
+}
 
+pub trait XMLElementVec: XMLElement {
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>
     where
         E: Into<Option<BytesEnd<'a>>>,

--- a/src/eutils.rs
+++ b/src/eutils.rs
@@ -136,17 +136,16 @@ pub fn fetch_data(db: EntrezDb, id: &str, r#type: &str, mode: &str) -> DataType 
 #[cfg(test)]
 mod tests {
     use crate::{build_fetch_url, build_search_url, get_local_xml, parse_xml, DataType, EntrezDb};
-    use std::fs;
 
     #[test]
     fn search_url() {
-        let url = build_search_url(EntrezDb::Protein, "deaminase");
+        let _url = build_search_url(EntrezDb::Protein, "deaminase");
     }
 
     #[test]
     fn test_protein() {
         let id = "2520667272";
-        let url = build_fetch_url(EntrezDb::Protein, id, "native", "xml");
+        let _url = build_fetch_url(EntrezDb::Protein, id, "native", "xml");
     }
 
     #[test]

--- a/src/eutils.rs
+++ b/src/eutils.rs
@@ -1,3 +1,5 @@
+//! Helper functions that deal with Entrez eUtils
+
 use crate::seqset::BioSeqSet;
 use crate::parsing::XmlNode;
 use quick_xml::events::Event;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::seqset::BioSeqSet;
-use crate::XMLElement;
+use crate::XmlNode;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::fs;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -110,7 +110,7 @@ pub fn parse_xml(response: &str) -> Result<DataType, ()> {
         match reader.read_event().unwrap() {
             Event::Start(e) => {
                 if e.name() == BioSeqSet::start_bytes().name() {
-                    let set = BioSeqSet::from_reader(&mut reader);
+                    let set = BioSeqSet::from_reader(&mut reader).unwrap();
                     return Ok(DataType::BioSeqSet(set));
                 }
             }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use crate::seq::BioSeq;
 use crate::seqset::BioSeqSet;
 use crate::XMLElement;
 
@@ -114,10 +113,6 @@ pub fn parse_xml(response: &str) -> Result<DataType, ()> {
                     return Ok(DataType::BioSeqSet(set));
                 }
             }
-            Event::End(e) => {
-            }
-            Event::Empty(e) => {}
-            Event::Text(e) => {}
             Event::Eof => break,
             _ => ()
         }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::seqset::BioSeqSet;
-use crate::XmlNode;
+use crate::parsing::XmlNode;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::fs;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,8 +1,8 @@
-use std::fs;
-use quick_xml::events::Event;
-use quick_xml::Reader;
 use crate::seqset::BioSeqSet;
 use crate::XMLElement;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use std::fs;
 
 const BASE: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
 
@@ -36,7 +36,7 @@ pub enum EntrezDb {
     Snp,
     Sra,
     Structure,
-    Taxonomy
+    Taxonomy,
 }
 impl EntrezDb {
     pub fn as_str(&self) -> &str {
@@ -67,7 +67,7 @@ impl EntrezDb {
             Self::Snp => "snp",
             Self::Sra => "sra",
             Self::Structure => "structure",
-            Self::Taxonomy => "taxonomy"
+            Self::Taxonomy => "taxonomy",
         }
     }
 }
@@ -100,7 +100,7 @@ pub fn build_fetch_url(db: EntrezDb, id: &str, r#type: &str, mode: &str) -> Stri
 pub enum DataType {
     BioSeqSet(BioSeqSet),
     /// placeholder for other types
-    EtAl
+    EtAl,
 }
 
 pub fn parse_xml(response: &str) -> Result<DataType, ()> {
@@ -114,34 +114,27 @@ pub fn parse_xml(response: &str) -> Result<DataType, ()> {
                 }
             }
             Event::Eof => break,
-            _ => ()
+            _ => (),
         }
     }
-    return Err(())
+    return Err(());
 }
 
 pub fn get_local_xml(path: &str) -> String {
     let file = fs::read(path);
-    return
-        file.unwrap()
-            .escape_ascii()
-            .to_string()
+    return file.unwrap().escape_ascii().to_string();
 }
 
 pub fn fetch_data(db: EntrezDb, id: &str, r#type: &str, mode: &str) -> DataType {
     let url = build_fetch_url(db, id, r#type, mode);
-    let response =
-        reqwest::blocking::get(url)
-            .unwrap()
-            .text()
-            .unwrap();
+    let response = reqwest::blocking::get(url).unwrap().text().unwrap();
     parse_xml(response.as_str()).unwrap()
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::{build_fetch_url, build_search_url, get_local_xml, parse_xml, DataType, EntrezDb};
     use std::fs;
-    use crate::{build_fetch_url, build_search_url, DataType, EntrezDb, get_local_xml, parse_xml};
 
     #[test]
     fn search_url() {
@@ -159,10 +152,9 @@ mod tests {
         let data = get_local_xml("tests/data/2519734237.xml");
         match parse_xml(data.as_str()).unwrap() {
             DataType::BioSeqSet(_) => (),
-            _ => assert!(false)
+            _ => assert!(false),
         }
     }
-
 
     #[test]
     fn test_article_set() {
@@ -170,13 +162,8 @@ mod tests {
         let db = EntrezDb::PubMed;
 
         let url = build_fetch_url(db, id, "xml", "xml");
-        let _ =
-            reqwest::blocking::get(url)
-                .unwrap()
-                .text()
-                .unwrap();
+        let _ = reqwest::blocking::get(url).unwrap().text().unwrap();
         //let expected = from_str(text.as_str()).unwrap();
         //assert!(expected.is_empty().not())
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ extern crate num;
 extern crate quick_xml;
 
 pub mod asn;
-pub mod helpers;
+pub mod eutils;
 pub mod parsing;
 
 pub use asn::*;
-pub use helpers::*;
+pub use eutils::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
+#[macro_use] extern crate enum_primitive;
+extern crate num;
+extern crate quick_xml;
+
 pub mod asn;
 pub mod helpers;
 mod element;
+mod parsing_utils;
 
 pub use asn::*;
 pub use helpers::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,8 @@ extern crate num;
 extern crate quick_xml;
 
 pub mod asn;
-mod element;
 pub mod helpers;
-mod parsing_utils;
+pub mod parsing;
 
 pub use asn::*;
-pub use element::*;
 pub use helpers::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
-#[macro_use] extern crate enum_primitive;
+#[macro_use]
+extern crate enum_primitive;
 extern crate num;
 extern crate quick_xml;
 
 pub mod asn;
-pub mod helpers;
 mod element;
+pub mod helpers;
 mod parsing_utils;
 
 pub use asn::*;
-pub use helpers::*;
 pub use element::*;
+pub use helpers::*;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,5 +1,7 @@
 mod node;
 mod utils;
+mod unexpected;
 
 pub use node::*;
 pub use utils::*;
+pub use unexpected::*;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,0 +1,5 @@
+mod node;
+mod utils;
+
+pub use node::*;
+pub use utils::*;

--- a/src/parsing/node.rs
+++ b/src/parsing/node.rs
@@ -64,7 +64,7 @@ pub trait XmlVecNode: XmlNode {
 
     /// Parse XML data as multiple [`XmlNode`] objects contained by [`Vec`]
     ///
-    /// [`Self::vec_from_reader()`] (or the helper function [`crate::parsing_utils::read_vec_node()`])
+    /// [`Self::vec_from_reader()`] (or the helper function [`crate::parsing::utils::read_vec_node()`])
     /// should be used to parse multiple [`XmlNode`] objects into a vector at once. Using these helper
     /// functions reduces errors in parsing implementation.
     fn vec_from_reader<'a, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<Self>

--- a/src/parsing/unexpected.rs
+++ b/src/parsing/unexpected.rs
@@ -1,0 +1,29 @@
+use quick_xml::events::BytesStart;
+use quick_xml::name::QName;
+
+/// Watchdog that guarantees all tags are being parsed.
+///
+/// If a particular tag is known about, but not yet implemented, it should be added to
+/// the internal container. When a tag is encountered that is known, a warning will be
+/// printed to stderr, however, when a tag that is not known is encountered, the program
+/// panics. The intention is to not overlook any tag elements given by the eutils. The
+/// internal store of unimplemented tags is a method of accountability.
+///
+/// Internal tags typically object fields and enum variants.
+pub struct UnexpectedTags<'a>(pub &'a [BytesStart<'a>]);
+
+impl UnexpectedTags<'_> {
+    /// See if a given tag is accounted for
+    pub fn check(&self, current: &QName) {
+        let mut expected = false;
+        for tag in self.0.iter() {
+            if *current == tag.name() {
+                expected = true;
+                eprintln!("Encountered XML tag {}, which has not been implemented yet...", tag.escape_ascii().to_string())
+            }
+        }
+        if !expected {
+            panic!("Encountered {}, which has not been implemented yet...", current.0.escape_ascii().to_string());
+        }
+    }
+}

--- a/src/parsing/utils.rs
+++ b/src/parsing/utils.rs
@@ -1,11 +1,9 @@
-//! Utility wrappers for parsing XML data into [`XmlNode`] and [`XmlValue`] structures.
-
-use crate::{XmlNode, XmlVecNode, XmlValue};
-use atoi::{atoi, FromRadix10SignedChecked};
-use quick_xml::events::{BytesEnd, BytesStart, Event};
-use quick_xml::name::QName;
 use quick_xml::Reader;
+use quick_xml::events::{BytesEnd, BytesStart, Event};
+use atoi::FromRadix10SignedChecked;
+use quick_xml::name::QName;
 use std::ops::Deref;
+use crate::parsing::{XmlNode, XmlValue, XmlVecNode};
 
 /// [`Reader`] that returns bytes
 ///
@@ -21,7 +19,7 @@ pub fn bytes_to_int<T>(text: &[u8]) -> T
 where
     T: FromRadix10SignedChecked,
 {
-    atoi::<T>(text.as_ref()).expect("Conversion error")
+    atoi::atoi::<T>(text.as_ref()).expect("Conversion error")
 }
 
 /// Parse the given bytes into a [`String`]

--- a/src/parsing/utils.rs
+++ b/src/parsing/utils.rs
@@ -1,7 +1,6 @@
 use quick_xml::Reader;
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use atoi::FromRadix10SignedChecked;
-use quick_xml::name::QName;
 use std::ops::Deref;
 use crate::parsing::{XmlNode, XmlValue, XmlVecNode};
 
@@ -141,19 +140,6 @@ where
     E: Into<Option<BytesEnd<'a>>>,
 {
     T::vec_from_reader(reader, end)
-}
-
-pub fn check_unexpected(current: &QName, forbidden: &[BytesStart<'static>]) {
-    let mut expected = false;
-    for tag in forbidden.iter() {
-        if *current == tag.name() {
-            expected = true;
-            eprintln!("Encountered XML tag {}, which has not been implemented yet...", tag.escape_ascii().to_string())
-        }
-    }
-    if !expected {
-        panic!("Encountered {}, which has not been implemented yet...", current.0.escape_ascii().to_string());
-    }
 }
 
 fn is_alphanum(text: &str) -> bool {

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -142,7 +142,7 @@ where
     T::vec_from_reader(reader, end)
 }
 
-pub fn check_unimplemented(current: &QName, forbidden: &[BytesStart<'static>]) {
+pub fn check_unexpected(current: &QName, forbidden: &[BytesStart<'static>]) {
     for tag in forbidden.iter() {
         if *current == tag.name() {
 

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -143,11 +143,15 @@ where
 }
 
 pub fn check_unexpected(current: &QName, forbidden: &[BytesStart<'static>]) {
+    let mut expected = false;
     for tag in forbidden.iter() {
         if *current == tag.name() {
-
+            expected = true;
             eprintln!("Encountered XML tag {}, which has not been implemented yet...", tag.escape_ascii().to_string())
         }
+    }
+    if !expected {
+        panic!("Encountered {}, which has not been implemented yet...", current.0.escape_ascii().to_string());
     }
 }
 

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -10,73 +10,6 @@ use std::ops::Deref;
 /// Used when XML is read from Entrez or file.
 pub type XmlReader<'a> = Reader<&'a [u8]>;
 
-/// Parses a single [`BytesText`] event and sets external variable
-///
-/// Used for building structs.
-///
-/// # Arguments
-///
-/// - `current`: name of current [`BytesStart`]. Used to check if XML data should be parsed.
-/// - `element`: start element that encapsulates desired text
-/// - `to`: external variable to parse to
-/// - `reader`: [`XmlReader`]
-pub fn parse_string_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
-where
-    T: From<String>,
-{
-    if *current == element.name() {
-        let text = read_string(reader);
-        if text.is_some() {
-            *to = text.unwrap().into();
-        }
-    }
-}
-
-/// Parses a single [`BytesText`] event and sets external variable
-///
-/// Used for building structs.
-///
-/// # Arguments
-///
-/// - `current`: name of current [`BytesStart`]. Used to check if XML data should be parsed.
-/// - `element`: start element that encapsulates desired value
-/// - `to`: external variable to parse integer into
-/// - `reader`: [`XmlReader`]
-pub fn parse_int_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
-where
-    T: FromRadix10SignedChecked,
-{
-    if *current == element.name() {
-        let text = read_int(reader);
-        if text.is_some() {
-            *to = text.unwrap();
-        }
-    }
-}
-
-/// Parses a single [`BytesText`] event and sets external variable
-///
-/// Used for building structs.
-///
-/// # Arguments
-///
-/// - `current`: name of current [`BytesStart`]. Used to check if XML data should be parsed.
-/// - `element`: start element that encapsulates desired value
-/// - `to`: external variable to parse integer into
-/// - `reader`: [`XmlReader`]
-pub fn parse_int_to_option<T>(
-    current: &QName,
-    element: &BytesStart,
-    to: &mut Option<T>,
-    reader: &mut XmlReader,
-) where
-    T: FromRadix10SignedChecked,
-{
-    if *current == element.name() {
-        *to = read_int(reader);
-    }
-}
-
 /// Parse the given bytes into an integer
 ///
 /// # Panics
@@ -94,26 +27,9 @@ pub fn bytes_to_string(text: &[u8]) -> String {
     text.escape_ascii().to_string()
 }
 
-pub fn parse_attribute<T: XmlValue>(current: &BytesStart, element: &BytesStart) -> Option<T> {
-    if current.name() == element.name() {
-        T::from_attributes(current.html_attributes())
-    } else {
-        None
-    }
-}
-
-pub fn parse_attribute_to<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut T){
-    let value = parse_attribute(current, element);
-    if value.is_some() {
-        *to = value.unwrap()
-    }
-}
-
-pub fn parse_attribute_to_option<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut Option<T>){
-    let value = parse_attribute(current, element);
-    if value.is_some() {
-        *to = value
-    }
+/// parse the given tag for its attributes
+pub fn read_attributes<T: XmlValue>(current: &BytesStart) -> Option<T> {
+    T::from_attributes(current.html_attributes())
 }
 
 /// Parses the next [`Event::Text`] as an integer
@@ -219,63 +135,11 @@ where
 ///
 /// # Returns
 /// Parsed object contained by `end`
-pub fn parse_vec_node<'a, T: XmlVecNode, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<T>
+pub fn read_vec_node<'a, T: XmlVecNode, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<T>
 where
     E: Into<Option<BytesEnd<'a>>>,
 {
     T::vec_from_reader(reader, end)
-}
-
-/// Used for parsing nodes denoted by `element` and setting to an external variable, `to`
-pub fn parse_node_to<T: XmlNode>(
-    current: &QName,
-    element: &BytesStart,
-    to: &mut T,
-    reader: &mut XmlReader,
-) {
-    if *current == element.name() {
-        if let Some(node) = read_node(reader) {
-            *to = node
-        }
-    }
-}
-
-/// Used for parsing vec nodes denoted by `element` and setting to an external variable, `to`
-pub fn parse_vec_node_to<T: XmlVecNode>(
-    current: &QName,
-    element: &BytesStart,
-    to: &mut Vec<T>,
-    reader: &mut XmlReader,
-) {
-    if *current == element.name() {
-        *to = parse_vec_node(reader, element.to_end())
-    }
-}
-
-/// Used for parsing nodes denoted by `element` and setting to an external option, `to`
-pub fn parse_node_to_option<T: XmlNode>(
-    current: &QName,
-    element: &BytesStart,
-    to: &mut Option<T>,
-    reader: &mut XmlReader,
-) {
-    if *current == element.name() {
-        let node = read_node(reader);
-        if node.is_some() {
-            *to = node
-        }
-    }
-}
-
-pub fn parse_vec_node_to_option<T: XmlVecNode>(
-    current: &QName,
-    element: &BytesStart,
-    to: &mut Option<Vec<T>>,
-    reader: &mut XmlReader,
-) {
-    if *current == element.name() {
-        *to = parse_vec_node(reader, element.to_end()).into()
-    }
 }
 
 pub fn check_unimplemented(current: &QName, forbidden: &[BytesStart<'static>]) {

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,3 +1,5 @@
+//! Utility wrappers for parsing XML data into [`XmlNode`] and [`XmlValue`] structures.
+
 use crate::{XmlNode, XmlVecNode, XmlValue};
 use atoi::{atoi, FromRadix10SignedChecked};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
@@ -52,7 +54,7 @@ pub fn read_real(reader: &mut XmlReader) -> Option<String> {
     }
 }
 
-/// Parses the next [`Event::Text`] as an integer
+/// Parses the next available [`Event::Text`] data as an integer
 pub fn read_string(reader: &mut XmlReader) -> Option<String> {
     if let Event::Text(text) = reader.read_event().unwrap() {
         bytes_to_string(text.deref()).into()
@@ -61,6 +63,7 @@ pub fn read_string(reader: &mut XmlReader) -> Option<String> {
     }
 }
 
+/// Parses the next available XML data as a [`XmlNode`]
 pub fn read_node<T: XmlNode>(reader: &mut XmlReader) -> Option<T> {
     T::from_reader(reader)
 }

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -4,7 +4,6 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader;
 use std::ops::Deref;
-use std::str::FromStr;
 
 /// [`Reader`] that returns bytes
 ///

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,8 +1,8 @@
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Deref};
 use atoi::{atoi, FromRadix10Checked, FromRadix10SignedChecked};
 use num::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One, Zero};
 use num::traits::{NumAssign, NumOps};
-use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader;
 use crate::XMLElement;
@@ -21,11 +21,22 @@ where
     }
 }
 
+fn parse_num<T>(text: &[u8]) -> T
+where
+    T: FromRadix10SignedChecked
+{
+    atoi::<T>(text.as_ref()).expect("Conversion error")
+}
+
+fn parse_text(text: &[u8]) -> String {
+    text.escape_ascii().to_string()
+}
+
 pub fn get_next_num<T>(reader: &mut Reader<&[u8]>) -> T
 where
     T: FromRadix10SignedChecked {
     if let Event::Text(text) = reader.read_event().unwrap() {
-        return atoi::<T>(text.as_ref()).expect("Conversion error");
+        parse_num(text.deref())
     }
     else {
         panic!("Incorrectly formatted number");
@@ -34,11 +45,75 @@ where
 
 pub fn get_next_text(reader: &mut Reader<&[u8]>) -> Option<String> {
     if let Event::Text(text) = reader.read_event().unwrap() {
-        return Some(text.escape_ascii().to_string())
+        return parse_text(text.deref()).into()
     }
     return None
 }
 
 pub fn bad_element_formatting(element: &BytesStart) {
-    panic!("Incorrectly formatted element {}", element.name().0.escape_ascii().to_string());
+    panic!("Incorrectly formatted element {}", parse_text(element.name().0));
+}
+
+pub fn get_vec_text(reader: &mut Reader<&[u8]>, end: &BytesEnd) -> Vec<String>
+{
+    let mut items = Vec::new();
+    loop {
+        match reader.read_event().unwrap() {
+                Event::Text(text) => {
+                    let text =
+                        parse_text(text.deref())
+                            .trim()
+                            .to_string();
+                    if !(text == "\\\\n" || text.is_empty()) {
+                        items.push(text)
+                    }
+                },
+            Event::End(e) => {
+                if e.name() == end.name() {
+                    return items
+                }
+            }
+            _ => ()
+        }
+    }
+}
+
+pub fn get_vec_num<T>(reader: &mut Reader<&[u8]>, end: &BytesEnd) -> Vec<T>
+    where
+        T: FromRadix10SignedChecked,
+{
+    let mut nums = Vec::new();
+    loop {
+        match reader.read_event().unwrap() {
+            Event::Text(text) => nums.push(parse_num(text.deref())),
+            Event::End(e) => {
+                if e.name() == end.name() {
+                    return nums
+                }
+            }
+            _ => ()
+        }
+    }
+}
+
+pub fn get_vec<T, F>(reader: &mut Reader<&[u8]>, item_element: &BytesStart, parser: &F, end: &BytesEnd) -> Vec<T>
+    where
+        F: Fn(&mut Reader<&[u8]>) -> Option<T>
+{
+    let mut items = Vec::new();
+    loop {
+        match reader.read_event().unwrap() {
+            Event::Start(e) => {
+                if e.name() == item_element.name() {
+                    items.push(parser(reader).unwrap());
+                }
+            }
+            Event::End(e) => {
+                if e.name() == end.name() {
+                    return items
+                }
+            }
+            _ => ()
+        }
+    }
 }

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,3 +1,7 @@
+use std::ops::AddAssign;
+use atoi::{atoi, FromRadix10Checked, FromRadix10SignedChecked};
+use num::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One, Zero};
+use num::traits::{NumAssign, NumOps};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader;
@@ -14,6 +18,17 @@ where
         else {
             *field = text.unwrap().into();
         }
+    }
+}
+
+pub fn get_next_num<T>(reader: &mut Reader<&[u8]>) -> T
+where
+    T: FromRadix10SignedChecked {
+    if let Event::Text(text) = reader.read_event().unwrap() {
+        return atoi::<T>(text.as_ref()).expect("Conversion error");
+    }
+    else {
+        panic!("Incorrectly formatted number");
     }
 }
 

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,4 +1,4 @@
-use crate::{XMLElement, XMLElementVec, XmlValue};
+use crate::{XmlNode, XmlVecNode, XmlValue};
 use atoi::{atoi, FromRadix10SignedChecked};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::name::QName;
@@ -139,7 +139,7 @@ pub fn read_string(reader: &mut XmlReader) -> Option<String> {
     }
 }
 
-pub fn read_node<T: XMLElement>(reader: &mut XmlReader) -> Option<T> {
+pub fn read_node<T: XmlNode>(reader: &mut XmlReader) -> Option<T> {
     T::from_reader(reader)
 }
 
@@ -207,7 +207,7 @@ where
 ///
 /// # Returns
 /// Parsed object contained by `end`
-pub fn parse_vec_node<'a, T: XMLElementVec, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<T>
+pub fn parse_vec_node<'a, T: XmlVecNode, E>(reader: &mut Reader<&[u8]>, end: E) -> Vec<T>
 where
     E: Into<Option<BytesEnd<'a>>>,
 {
@@ -215,7 +215,7 @@ where
 }
 
 /// Used for parsing nodes denoted by `element` and setting to an external variable, `to`
-pub fn parse_node_to<T: XMLElement>(
+pub fn parse_node_to<T: XmlNode>(
     current: &QName,
     element: &BytesStart,
     to: &mut T,
@@ -229,7 +229,7 @@ pub fn parse_node_to<T: XMLElement>(
 }
 
 /// Used for parsing vec nodes denoted by `element` and setting to an external variable, `to`
-pub fn parse_vec_node_to<T: XMLElementVec>(
+pub fn parse_vec_node_to<T: XmlVecNode>(
     current: &QName,
     element: &BytesStart,
     to: &mut Vec<T>,
@@ -241,7 +241,7 @@ pub fn parse_vec_node_to<T: XMLElementVec>(
 }
 
 /// Used for parsing nodes denoted by `element` and setting to an external option, `to`
-pub fn parse_node_to_option<T: XMLElement>(
+pub fn parse_node_to_option<T: XmlNode>(
     current: &QName,
     element: &BytesStart,
     to: &mut Option<T>,
@@ -255,7 +255,7 @@ pub fn parse_node_to_option<T: XMLElement>(
     }
 }
 
-pub fn parse_vec_node_to_option<T: XMLElementVec>(
+pub fn parse_vec_node_to_option<T: XmlVecNode>(
     current: &QName,
     element: &BytesStart,
     to: &mut Option<Vec<T>>,

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -263,3 +263,12 @@ pub fn parse_vec_node_to_option<T: XmlVecNode>(
         *to = parse_vec_node(reader, element.to_end()).into()
     }
 }
+
+pub fn check_unimplemented(current: &QName, forbidden: &[&BytesStart<'static>]) {
+    for tag in forbidden.iter() {
+        if *current == tag.name() {
+
+            eprintln!("Encountered XML tag {}, which has not been implemented yet...", tag.escape_ascii().to_string())
+        }
+    }
+}

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,4 +1,4 @@
-use crate::{XMLElement, XMLElementVec};
+use crate::{XMLElement, XMLElementVec, XmlValue};
 use atoi::{atoi, FromRadix10SignedChecked};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::name::QName;
@@ -92,6 +92,30 @@ where
 /// Parse the given bytes into a [`String`]
 pub fn bytes_to_string(text: &[u8]) -> String {
     text.escape_ascii().to_string()
+}
+
+pub fn parse_attribute<T: XmlValue>(current: &BytesStart, element: &BytesStart, reader: &mut XmlReader) -> Option<T> {
+    let current_str = current.name().0.escape_ascii().to_string();
+    let element_str = element.name().0.escape_ascii().to_string();
+    if current.name() == element.name() {
+        T::from_attributes(current.html_attributes())
+    } else {
+        None
+    }
+}
+
+pub fn parse_attribute_to<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut T, reader: &mut XmlReader){
+    let value = parse_attribute(current, element, reader);
+    if value.is_some() {
+        *to = value.unwrap()
+    }
+}
+
+pub fn parse_attribute_to_option<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut Option<T>, reader: &mut XmlReader){
+    let value = parse_attribute(current, element, reader);
+    if value.is_some() {
+        *to = value
+    }
 }
 
 /// Parses the next [`Event::Text`] as an integer

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,8 +1,6 @@
-use std::ops::{AddAssign, Deref};
-use atoi::{atoi, FromRadix10Checked, FromRadix10SignedChecked};
-use num::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One, Zero};
-use num::traits::{NumAssign, NumOps};
-use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use std::ops::{Deref};
+use atoi::{atoi, FromRadix10SignedChecked};
+use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader;
 use crate::{XMLElement, XMLElementVec};
@@ -22,7 +20,7 @@ pub type XmlReader<'a> = Reader<&'a [u8]>;
 /// - `element`: start element that encapsulates desired text
 /// - `to`: external variable to parse to
 /// - `reader`: [`XmlReader`]
-pub fn parse_next_string_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
+pub fn parse_string_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
 where
     T: From<String> {
     if *current == element.name() {
@@ -43,7 +41,7 @@ where
 /// - `element`: start element that encapsulates desired value
 /// - `to`: external variable to parse integer into
 /// - `reader`: [`XmlReader`]
-pub fn parse_next_int_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
+pub fn parse_int_to<T>(current: &QName, element: &BytesStart, to: &mut T, reader: &mut XmlReader)
 where
 T: FromRadix10SignedChecked,
 {
@@ -65,7 +63,7 @@ T: FromRadix10SignedChecked,
 /// - `element`: start element that encapsulates desired value
 /// - `to`: external variable to parse integer into
 /// - `reader`: [`XmlReader`]
-pub fn parse_next_int_to_option<T>(current: &QName, element: &BytesStart, to: &mut Option<T>, reader: &mut XmlReader)
+pub fn parse_int_to_option<T>(current: &QName, element: &BytesStart, to: &mut Option<T>, reader: &mut XmlReader)
     where
         T: FromRadix10SignedChecked,
 {
@@ -211,6 +209,19 @@ pub fn parse_vec_node_to<T: XMLElementVec>(current: &QName, element: &BytesStart
 /// Used for parsing nodes denoted by `element` and setting to an external option, `to`
 pub fn parse_node_to_option<T: XMLElement>(current: &QName, element: &BytesStart, to: &mut Option<T>, reader: &mut XmlReader) {
     if *current == element.name() {
-        *to = T::from_reader(reader)
+        let node = read_node(reader);
+        if node.is_some() {
+            *to = node
+        }
+    }
+}
+
+pub fn parse_vec_node_to_option<T: XMLElementVec>(current: &QName,
+                                                  element: &BytesStart,
+                                                  to: &mut Option<Vec<T>>,
+                                                  reader: &mut XmlReader) {
+    if *current == element.name() {
+        *to = parse_vec_node(reader, element.to_end())
+            .into()
     }
 }

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -1,0 +1,29 @@
+use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::name::QName;
+use quick_xml::Reader;
+use crate::XMLElement;
+
+pub fn try_field<T>(current: &QName, element: &BytesStart, field: &mut T, reader: &mut Reader<&[u8]>)
+where
+    T: From<String> {
+    if *current == element.name() {
+        let text = get_next_text(reader);
+        if text.is_none() {
+            bad_element_formatting(element);
+        }
+        else {
+            *field = text.unwrap().into();
+        }
+    }
+}
+
+pub fn get_next_text(reader: &mut Reader<&[u8]>) -> Option<String> {
+    if let Event::Text(text) = reader.read_event().unwrap() {
+        return Some(text.escape_ascii().to_string())
+    }
+    return None
+}
+
+pub fn bad_element_formatting(element: &BytesStart) {
+    panic!("Incorrectly formatted element {}", element.name().0.escape_ascii().to_string());
+}

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -94,9 +94,7 @@ pub fn bytes_to_string(text: &[u8]) -> String {
     text.escape_ascii().to_string()
 }
 
-pub fn parse_attribute<T: XmlValue>(current: &BytesStart, element: &BytesStart, reader: &mut XmlReader) -> Option<T> {
-    let current_str = current.name().0.escape_ascii().to_string();
-    let element_str = element.name().0.escape_ascii().to_string();
+pub fn parse_attribute<T: XmlValue>(current: &BytesStart, element: &BytesStart) -> Option<T> {
     if current.name() == element.name() {
         T::from_attributes(current.html_attributes())
     } else {
@@ -104,15 +102,15 @@ pub fn parse_attribute<T: XmlValue>(current: &BytesStart, element: &BytesStart, 
     }
 }
 
-pub fn parse_attribute_to<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut T, reader: &mut XmlReader){
-    let value = parse_attribute(current, element, reader);
+pub fn parse_attribute_to<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut T){
+    let value = parse_attribute(current, element);
     if value.is_some() {
         *to = value.unwrap()
     }
 }
 
-pub fn parse_attribute_to_option<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut Option<T>, reader: &mut XmlReader){
-    let value = parse_attribute(current, element, reader);
+pub fn parse_attribute_to_option<T: XmlValue>(current: &BytesStart, element: &BytesStart, to: &mut Option<T>){
+    let value = parse_attribute(current, element);
     if value.is_some() {
         *to = value
     }

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -278,7 +278,7 @@ pub fn parse_vec_node_to_option<T: XmlVecNode>(
     }
 }
 
-pub fn check_unimplemented(current: &QName, forbidden: &[&BytesStart<'static>]) {
+pub fn check_unimplemented(current: &QName, forbidden: &[BytesStart<'static>]) {
     for tag in forbidden.iter() {
         if *current == tag.name() {
 

--- a/src/parsing_utils.rs
+++ b/src/parsing_utils.rs
@@ -128,6 +128,14 @@ where
     }
 }
 
+pub fn read_real(reader: &mut XmlReader) -> Option<String> {
+    if let Event::Text(text) = reader.read_event().unwrap() {
+        bytes_to_string(text.deref()).into()
+    } else {
+        None
+    }
+}
+
 /// Parses the next [`Event::Text`] as an integer
 pub fn read_string(reader: &mut XmlReader) -> Option<String> {
     if let Event::Text(text) = reader.read_event().unwrap() {

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -6,7 +6,7 @@ use ncbi::general::{
 };
 use ncbi::r#pub::Pub;
 use ncbi::seq::{BioMol, BioSeq, DeltaSeq, Mol, MolInfo, MolTech, PubDesc, Repr, SeqAnnotData, SeqDesc, SeqExt, SeqInst, Strand};
-use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
+use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SeqFeatData, SubSource, SubSourceSubType};
 use ncbi::seqloc::{NaStrand, SeqId, SeqInterval, SeqLoc, TextseqId};
 use ncbi::seqset::{BioSeqSet, SeqEntry};
 use ncbi::{get_local_xml, parse_xml, DataType};
@@ -616,18 +616,32 @@ fn parse_bioseq_inst() {
 fn parse_bioseq_annot() {
     let bioseq = get_bioseq(DATA1);
 
+    // total number of feat id's
+    let feats: usize = 176;
+
+    // total number of occurrences of `SeqFeatData::Gene`
+    let expected_genes: usize = 88;
+
     assert!(bioseq.annot.is_some());
-    let feats = 176 as usize;
 
     if let Some(annot) = bioseq.annot {
         let annot = annot.get(0).unwrap();
         if let SeqAnnotData::FTable(ftable) = &annot.data {
             assert_eq!(ftable.len(), feats);
+
+            // counter for gene features
+            let mut genes: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if let SeqFeatData::Gene(_) = feat.data {
+                    genes += 1;
+                }
+            }
+            assert_eq!(expected_genes, genes)
         } else {
             assert!(false);
         }
 
-    } else {
-        assert!(false)
     }
 }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -622,6 +622,8 @@ fn parse_bioseq_annot() {
     // total number of occurrences of `SeqFeatData::Gene`
     let expected_genes: usize = 88;
     let expected_cdregions: usize = 88;
+    let expected_products: usize = 87;
+
     let genetic_code = Some(vec![GeneticCodeOpt::Id(11)]);
 
     assert!(bioseq.annot.is_some());
@@ -637,6 +639,7 @@ fn parse_bioseq_annot() {
             // counter for gene features
             let mut genes: usize = 0;
             let mut cdregions: usize = 0;
+            let mut products: usize = 0;
 
             // inspect parsed features
             for feat in ftable.iter() {
@@ -649,6 +652,10 @@ fn parse_bioseq_annot() {
                     assert_eq!(cdregion.code, genetic_code);
                     cdregions += 1;
                 }
+
+                if feat.product.is_some() {
+                    products += 1;
+                }
             }
 
             // assert parsed features
@@ -657,6 +664,8 @@ fn parse_bioseq_annot() {
 
             assert!(has_cdregion_data);
             assert_eq!(expected_cdregions, cdregions);
+
+            assert_eq!(expected_products, products);
         } else {
             assert!(false, "data value is not ftable");
         }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -6,7 +6,7 @@ use ncbi::general::{
 };
 use ncbi::r#pub::Pub;
 use ncbi::seq::{BioMol, BioSeq, DeltaSeq, Mol, MolInfo, MolTech, PubDesc, Repr, SeqAnnotData, SeqDesc, SeqExt, SeqInst, Strand};
-use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, GeneticCode, GeneticCodeOpt, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SeqFeat, SeqFeatData, SubSource, SubSourceSubType};
+use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, GeneticCodeOpt, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SeqFeatData, SubSource, SubSourceSubType};
 use ncbi::seqloc::{NaStrand, SeqId, SeqInterval, SeqLoc, TextseqId};
 use ncbi::seqset::{BioSeqSet, SeqEntry};
 use ncbi::{get_local_xml, parse_xml, DataType};

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -276,7 +276,21 @@ fn parse_bioseq_desc_pub() {
     assert!(has_pub);
 }
 
+#[test]
+fn parse_bioseq_desc_comment() {
+    let bioseq = get_bioseq(DATA1);
 
+    let expected = "The annotation was added by the NCBI Prokaryotic Genome Annotation Pipeline (PGAP). Information about PGAP can be found here: https://www.ncbi.nlm.nih.gov/genome/annotation_prok/".to_string();
+
+    let mut has_comment = false;
+    for entry in bioseq.descr.unwrap().iter() {
+        if let SeqDesc::Comment(comment) = entry {
+            assert_eq!(*comment, expected);
+            has_comment = true;
+        }
+    };
+    assert!(has_comment);
+}
 
 #[test]
 #[ignore]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -5,7 +5,7 @@ use ncbi::general::{
     Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject,
 };
 use ncbi::r#pub::Pub;
-use ncbi::seq::{BioMol, BioSeq, DeltaSeq, Mol, MolInfo, MolTech, PubDesc, Repr, SeqDesc, SeqExt, SeqInst, Strand};
+use ncbi::seq::{BioMol, BioSeq, DeltaSeq, Mol, MolInfo, MolTech, PubDesc, Repr, SeqAnnotData, SeqDesc, SeqExt, SeqInst, Strand};
 use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
 use ncbi::seqloc::{NaStrand, SeqId, SeqInterval, SeqLoc, TextseqId};
 use ncbi::seqset::{BioSeqSet, SeqEntry};
@@ -613,8 +613,21 @@ fn parse_bioseq_inst() {
 }
 
 #[test]
-#[ignore]
 fn parse_bioseq_annot() {
     let bioseq = get_bioseq(DATA1);
+
     assert!(bioseq.annot.is_some());
+    let feats = 176 as usize;
+
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            assert_eq!(ftable.len(), feats);
+        } else {
+            assert!(false);
+        }
+
+    } else {
+        assert!(false)
+    }
 }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -90,7 +90,7 @@ fn parse_bioseq_descr() {
     let bioseq = get_bioseq(DATA1);
 
     assert!(bioseq.descr.is_some());
-    assert_eq!(bioseq.descr.unwrap().len(), 10);
+    assert_eq!(bioseq.descr.unwrap().len(), 11);
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -2,7 +2,7 @@ use std::ops::Not;
 use quick_xml::se::to_string;
 use ncbi::{DataType, get_local_xml, parse_xml};
 use ncbi::biblio::{Affil, AffilStd, AuthList, AuthListNames, Author, CitGen, CitSub, CitSubMedium};
-use ncbi::general::{Date, DateStd, DbTag, NameStd, ObjectId, PersonId};
+use ncbi::general::{Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject};
 use ncbi::r#pub::{Pub, PubEquiv};
 use ncbi::seq::{BioMol, BioSeq, Mol, MolInfo, MolTech, PubDesc, SeqDesc};
 use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, BioSourceOrigin, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
@@ -290,6 +290,262 @@ fn parse_bioseq_desc_comment() {
         }
     };
     assert!(has_comment);
+}
+
+#[test]
+fn parse_bioseq_desc_user() {
+    let bioseq = get_bioseq(DATA1);
+
+    let expected1 = UserObject {
+        class: None,
+        r#type: ObjectId::Str("DBLink".to_string()),
+        data: vec![
+            UserField {
+                label: ObjectId::Str("BioSample".to_string()),
+                num: 1.into(),
+                data: UserData::Strs(vec!["SAMN33942939".to_string()]),
+            },
+            UserField {
+                label: ObjectId::Str("BioProject".to_string()),
+                num: 1.into(),
+                data: UserData::Strs(vec!["PRJNA224116".to_string()]),
+            },
+            UserField {
+                label: ObjectId::Str("Assembly".to_string()),
+                num: 1.into(),
+                data: UserData::Strs(vec!["GCF_030238925".to_string()]),
+            }
+        ],
+    };
+    let expected2 = UserObject {
+        class: None,
+        r#type: ObjectId::Str("StructuredComment".into()),
+        data: vec![
+            UserField {
+                label: ObjectId::Str("StructuredCommentPrefix".to_string()),
+                num: None,
+                data: UserData::Str("##Genome-Annotation-Data-START##".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Annotation Provider".to_string()),
+                num: None,
+                data: UserData::Str("NCBI RefSeq".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Annotation Date".to_string()),
+                num: None,
+                data: UserData::Str("06/09/2023 17:06:50".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Annotation Pipeline".to_string()),
+                num: None,
+                data: UserData::Str("NCBI Prokaryotic Genome Annotation Pipeline (PGAP)".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Annotation Method".to_string()),
+                num: None,
+                data: UserData::Str("Best-placed reference protein set; GeneMarkS-2+".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Annotation Software".to_string()),
+                num: None,
+                data: UserData::Str("6.5".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Features Annotated".to_string()),
+                num: None,
+                data: UserData::Str("Gene; CDS; rRNA; tRNA; ncRNA".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Genes (total)".to_string()),
+                num: None,
+                data: UserData::Str("5,288".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("CDSs (total)".to_string()),
+                num: None,
+                data: UserData::Str("5,202".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Genes (coding)".to_string()),
+                num: None,
+                data: UserData::Str("5,041".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("CDSs (with proteins)".to_string()),
+                num: None,
+                data: UserData::Str("5,041".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Genes (RNA)".to_string()),
+                num: None,
+                data: UserData::Str("86".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Genes (RNA)".to_string()),
+                num: None,
+                data: UserData::Str("2, 3, 6 (5S, 16S, 23S)".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("complete rRNAs".to_string()),
+                num: None,
+                data: UserData::Str("2 (5S)".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("partial rRNAs".to_string()),
+                num: None,
+                data: UserData::Str("3, 6 (16S, 23S)".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("tRNAs".to_string()),
+                num: None,
+                data: UserData::Str("64".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("ncRNAs".to_string()),
+                num: None,
+                data: UserData::Str("11".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (total)".to_string()),
+                num: None,
+                data: UserData::Str("161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("tRNAs".to_string()),
+                num: None,
+                data: UserData::Str("64".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("CDSs (without protein)".to_string()),
+                num: None,
+                data: UserData::Str("161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (ambiguous residues)".to_string()),
+                num: None,
+                data: UserData::Str("0 of 161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (frameshifted)".to_string()),
+                num: None,
+                data: UserData::Str("59 of 161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (incomplete)".to_string()),
+                num: None,
+                data: UserData::Str("107 of 161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (internal stop)".to_string()),
+                num: None,
+                data: UserData::Str("25 of 161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("Pseudo Genes (multiple problems)".to_string()),
+                num: None,
+                data: UserData::Str("27 of 161".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("StructuredCommentSuffix".to_string()),
+                num: None,
+                data: UserData::Str("##Genome-Annotation-Data-END##".to_string()),
+            },
+        ],
+    };
+    let expected3 = UserObject {
+        class: None,
+        r#type: ObjectId::Str("RefGeneTracking".to_string()),
+        data: vec![
+            UserField {
+                label: ObjectId::Str("Status".to_string()),
+                num: None,
+                data: UserData::Str("PIPELINE".to_string()),
+            },
+            UserField {
+                label: ObjectId::Str("IdenticalTo".to_string()),
+                num: None,
+                data: UserData::Fields(vec![
+                    UserField {
+                        label: ObjectId::Id(0),
+                        num: None,
+                        data: UserData::Fields(vec![
+                            UserField {
+                                label: ObjectId::Str("accession".to_string()),
+                                num: None,
+                                data: UserData::Str("JARQWN010000024.1".to_string()),
+                            }
+                        ]),
+                    }
+                ]),
+            }
+        ],
+    };
+    let expected4 = UserObject {
+        class: None,
+        r#type: ObjectId::Str("FeatureFetchPolicy".to_string()),
+        data: vec![UserField {
+            label: ObjectId::Str("Policy".to_string()),
+            num: None,
+            data: UserData::Str("OnlyNearFeatures".to_string()),
+        }],
+    };
+    let expected5 = UserObject {
+        class: None,
+        r#type: ObjectId::Str("StructuredComment".to_string()),
+        data: vec![
+            UserField {
+                label: ObjectId::Str("StructuredCommentPrefix".to_string()),
+                num: None,
+                data: UserData::Str("##Genome-Assembly-Data-START##".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("Assembly Method".to_string()),
+                num: None,
+                data: UserData::Str("SPAdes v. 1".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("Genome Representation".to_string()),
+                num: None,
+                data: UserData::Str("Full".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("Expected Final Version".to_string()),
+                num: None,
+                data: UserData::Str("Yes".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("Genome Coverage".to_string()),
+                num: None,
+                data: UserData::Str("100x".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("Sequencing Technology".to_string()),
+                num: None,
+                data: UserData::Str("Illumina HiSeq".to_string())
+            },
+            UserField {
+                label: ObjectId::Str("StructuredCommentSuffix".to_string()),
+                num: None,
+                data: UserData::Str("##Genome-Assembly-Data-END##".to_string())
+            },
+        ],
+    };
+
+    let expected = [expected1, expected2, expected3, expected4, expected5];
+
+    let mut has_user_object = false;
+    for entry in bioseq.descr.unwrap().iter() {
+        if let SeqDesc::User(object) = entry {
+            for exp in expected.iter() {
+                if object.r#type == exp.r#type {
+                    assert_eq!(object, exp)
+                }
+            }
+        }
+    }
+    assert!(has_user_object)
+
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -626,8 +626,9 @@ fn parse_bioseq_annot() {
         if let SeqAnnotData::FTable(ftable) = &annot.data {
             assert_eq!(ftable.len(), feats);
         }
+    } else {
+        assert!(false, "data value is not ftable");
     }
-
 }
 
 #[test]
@@ -664,10 +665,7 @@ fn parse_bioseq_annot_gene_feats() {
             assert!(has_gene_data);
             assert_eq!(expected_genes, genes);
 
-        } else {
-            assert!(false, "data value is not ftable");
         }
-
     }
 }
 
@@ -700,10 +698,7 @@ fn parse_bioseq_annot_cdregion_feats() {
             // assert parsed features
             assert!(has_cdregion_data);
             assert_eq!(expected_cdregions, cdregions);
-        } else {
-            assert!(false, "data value is not ftable");
         }
-
     }
 }
 
@@ -730,9 +725,33 @@ fn parse_bioseq_annot_feat_products() {
 
             // assert parsed features
             assert_eq!(expected_products, products);
-        } else {
-            assert!(false, "data value is not ftable");
         }
+    }
+}
 
+#[test]
+fn parse_bioseq_annot_feat_comments() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeat.products`
+    let expected_comments: usize = 1;
+
+    // track occurrence of object types
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for products
+            let mut comments: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if feat.comment.is_some() {
+                    comments += 1;
+                }
+            }
+
+            // assert parsed features
+            assert_eq!(expected_comments, comments);
+        }
     }
 }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -313,7 +313,7 @@ fn parse_bioseq_desc_user() {
             UserField {
                 label: ObjectId::Str("Assembly".to_string()),
                 num: 1.into(),
-                data: UserData::Strs(vec!["GCF_030238925".to_string()]),
+                data: UserData::Strs(vec!["GCF_030238925.1".to_string()]),
             }
         ],
     };
@@ -347,7 +347,7 @@ fn parse_bioseq_desc_user() {
                 data: UserData::Str("Best-placed reference protein set; GeneMarkS-2+".to_string()),
             },
             UserField {
-                label: ObjectId::Str("Annotation Software".to_string()),
+                label: ObjectId::Str("Annotation Software revision".to_string()),
                 num: None,
                 data: UserData::Str("6.5".to_string()),
             },
@@ -372,7 +372,7 @@ fn parse_bioseq_desc_user() {
                 data: UserData::Str("5,041".to_string()),
             },
             UserField {
-                label: ObjectId::Str("CDSs (with proteins)".to_string()),
+                label: ObjectId::Str("CDSs (with protein)".to_string()),
                 num: None,
                 data: UserData::Str("5,041".to_string()),
             },
@@ -382,7 +382,7 @@ fn parse_bioseq_desc_user() {
                 data: UserData::Str("86".to_string()),
             },
             UserField {
-                label: ObjectId::Str("Genes (RNA)".to_string()),
+                label: ObjectId::Str("rRNAs".to_string()),
                 num: None,
                 data: UserData::Str("2, 3, 6 (5S, 16S, 23S)".to_string()),
             },
@@ -410,11 +410,6 @@ fn parse_bioseq_desc_user() {
                 label: ObjectId::Str("Pseudo Genes (total)".to_string()),
                 num: None,
                 data: UserData::Str("161".to_string()),
-            },
-            UserField {
-                label: ObjectId::Str("tRNAs".to_string()),
-                num: None,
-                data: UserData::Str("64".to_string()),
             },
             UserField {
                 label: ObjectId::Str("CDSs (without protein)".to_string()),
@@ -539,7 +534,11 @@ fn parse_bioseq_desc_user() {
         if let SeqDesc::User(object) = entry {
             for exp in expected.iter() {
                 if object.r#type == exp.r#type {
-                    assert_eq!(object, exp)
+                    if object.r#type == ObjectId::Str("StructuredComment".to_string()) && object.data.first().unwrap() != exp.data.first().unwrap() {
+                        continue;
+                    }
+                    assert_eq!(object, exp);
+                    has_user_object = true;
                 }
             }
         }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -619,18 +619,31 @@ fn parse_bioseq_annot() {
     // total number of feat id's
     let feats: usize = 176;
 
+    assert!(bioseq.annot.is_some());
+
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            assert_eq!(ftable.len(), feats);
+        }
+    }
+
+}
+
+#[test]
+fn parse_bioseq_annot_gene_feats() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of feat id's
+    let feats: usize = 176;
+
     // total number of occurrences of `SeqFeatData::Gene`
     let expected_genes: usize = 88;
-    let expected_cdregions: usize = 88;
-    let expected_products: usize = 87;
-
-    let genetic_code = Some(vec![GeneticCodeOpt::Id(11)]);
 
     assert!(bioseq.annot.is_some());
 
     // track occurrence of object types
     let mut has_gene_data = false;
-    let mut has_cdregion_data = false;
     if let Some(annot) = bioseq.annot {
         let annot = annot.get(0).unwrap();
         if let SeqAnnotData::FTable(ftable) = &annot.data {
@@ -638,8 +651,6 @@ fn parse_bioseq_annot() {
 
             // counter for gene features
             let mut genes: usize = 0;
-            let mut cdregions: usize = 0;
-            let mut products: usize = 0;
 
             // inspect parsed features
             for feat in ftable.iter() {
@@ -647,24 +658,77 @@ fn parse_bioseq_annot() {
                     has_gene_data = true;
                     genes += 1;
                 }
-                else if let SeqFeatData::CdRegion(cdregion) = &feat.data {
-                    has_cdregion_data = true;
-                    assert_eq!(cdregion.code, genetic_code);
-                    cdregions += 1;
-                }
-
-                if feat.product.is_some() {
-                    products += 1;
-                }
             }
 
             // assert parsed features
             assert!(has_gene_data);
             assert_eq!(expected_genes, genes);
 
+        } else {
+            assert!(false, "data value is not ftable");
+        }
+
+    }
+}
+
+#[test]
+fn parse_bioseq_annot_cdregion_feats() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeatData::Gene`
+    let expected_cdregions: usize = 88;
+
+    let genetic_code = Some(vec![GeneticCodeOpt::Id(11)]);
+
+    // track occurrence of object types
+    let mut has_cdregion_data = false;
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for gene features
+            let mut cdregions: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if let SeqFeatData::CdRegion(cdregion) = &feat.data {
+                    has_cdregion_data = true;
+                    assert_eq!(cdregion.code, genetic_code);
+                    cdregions += 1;
+                }
+            }
+
+            // assert parsed features
             assert!(has_cdregion_data);
             assert_eq!(expected_cdregions, cdregions);
+        } else {
+            assert!(false, "data value is not ftable");
+        }
 
+    }
+}
+
+#[test]
+fn parse_bioseq_annot_feat_products() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeat.products`
+    let expected_products: usize = 87;
+
+    // track occurrence of object types
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for products
+            let mut products: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if feat.product.is_some() {
+                    products += 1;
+                }
+            }
+
+            // assert parsed features
             assert_eq!(expected_products, products);
         } else {
             assert!(false, "data value is not ftable");

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -1,12 +1,19 @@
-use std::ops::Not;
-use ncbi::{DataType, get_local_xml, parse_xml};
-use ncbi::biblio::{Affil, AffilStd, AuthList, AuthListNames, Author, CitGen, CitSub, CitSubMedium};
-use ncbi::general::{Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject};
+use ncbi::biblio::{
+    Affil, AffilStd, AuthList, AuthListNames, Author, CitGen, CitSub, CitSubMedium,
+};
+use ncbi::general::{
+    Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject,
+};
 use ncbi::r#pub::Pub;
 use ncbi::seq::{BioMol, BioSeq, MolInfo, MolTech, PubDesc, SeqDesc};
-use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
+use ncbi::seqfeat::{
+    BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice,
+    OrgRef, SubSource, SubSourceSubType,
+};
 use ncbi::seqloc::SeqId;
 use ncbi::seqset::{BioSeqSet, SeqEntry};
+use ncbi::{get_local_xml, parse_xml, DataType};
+use std::ops::Not;
 
 const DATA1: &str = "tests/data/2519734237.xml";
 
@@ -15,7 +22,7 @@ fn get_bioseq(path: &str) -> BioSeq {
     let entry = set.seq_set.get(0).unwrap();
     match entry {
         SeqEntry::Seq(data) => return data.clone(),
-        _ => panic!("Entry is not Bioseq")
+        _ => panic!("Entry is not Bioseq"),
     }
 }
 
@@ -23,9 +30,8 @@ fn get_seq_set(path: &str) -> BioSeqSet {
     let data = get_local_xml(path);
     let parsed = parse_xml(data.as_str()).unwrap();
     if let DataType::BioSeqSet(set) = parsed {
-        return set
-    }
-    else {
+        return set;
+    } else {
         panic!("No Bioseq set found")
     }
 }
@@ -44,7 +50,7 @@ fn parse_seq() {
     let entry = data.seq_set.get(0).unwrap();
     match entry {
         SeqEntry::Seq(_) => assert!(true),
-        _ => assert!(false)
+        _ => assert!(false),
     }
 }
 
@@ -60,19 +66,21 @@ fn parse_bioseq_id() {
                 assert_eq!(tag.db.as_str(), "WGS:NZ_JARQWN01");
                 if let ObjectId::Str(s) = &tag.tag {
                     assert_eq!(s.as_str(), "NODE_24_length_86489_cov_60.972353")
-                }
-                else {
+                } else {
                     assert!(false);
                 }
-            },
+            }
             SeqId::Other(text) => {
-                assert_eq!(text.accession.as_ref().unwrap().as_str(), "NZ_JARQWN010000024");
+                assert_eq!(
+                    text.accession.as_ref().unwrap().as_str(),
+                    "NZ_JARQWN010000024"
+                );
                 assert_eq!(*text.version.as_ref().unwrap(), 1);
                 assert!(text.name.is_none());
                 assert!(text.release.is_none());
             }
             SeqId::Gi(gi) => assert_eq!(*gi, 2519734237),
-            _ => ()
+            _ => (),
         }
     }
 }
@@ -89,7 +97,7 @@ fn parse_bioseq_descr() {
 fn parse_bioseq_descr_source() {
     let bioseq = get_bioseq(DATA1);
 
-    let subtype = vec![
+    let subtype = Some(vec![
         SubSource {
             subtype: SubSourceSubType::Country,
             name: "Australia".to_string(),
@@ -115,7 +123,7 @@ fn parse_bioseq_descr_source() {
             name: "UNIVERSITY OF SOUTH AUSTRALIA".to_string(),
             attrib: None,
         },
-    ].into();
+    ]);
     let expected = BioSource {
         genome: BioSourceGenome::Genomic,
         org: OrgRef {
@@ -190,34 +198,29 @@ fn parse_bioseq_desc_pub() {
         ("Hart", "Bradley", "B.J."),
         ("Venter", "Henrietta", "H."),
     ];
-    let authors = authors
-        .iter()
-        .map(|author| {
-            Author::new(
-                PersonId::Name(
-                    NameStd {
-                        last: author.0.to_string(),
-                        first: author.1.to_string().into(),
-                        initials: author.2.to_string().into(),
-                        ..NameStd::default()
-                    })
-            )
-        });
+    let authors = authors.iter().map(|author| {
+        Author::new(PersonId::Name(NameStd {
+            last: author.0.to_string(),
+            first: author.1.to_string().into(),
+            initials: author.2.to_string().into(),
+            ..NameStd::default()
+        }))
+    });
 
     let sub_authors = vec![Pub::Sub(CitSub {
         authors: AuthList {
-            names: AuthListNames::Std(
-                authors.clone().collect::<Vec<Author>>().into()),
+            names: AuthListNames::Std(authors.clone().collect::<Vec<Author>>().into()),
             affil: Affil::Std(AffilStd {
-                    affil: "University of South Australia".to_string().into(),
-                    div: "Clinical Health Sciences".to_string().into(),
-                    city: "Adelaide".to_string().into(),
-                    sub: "SA".to_string().into(),
-                    country: "Australia".to_string().into(),
-                    street: "Cnr North Terrace and Frome Rd".to_string().into(),
-                    postal_code: "5001".to_string().into(),
-                    ..AffilStd::default()
-                }).into()
+                affil: "University of South Australia".to_string().into(),
+                div: "Clinical Health Sciences".to_string().into(),
+                city: "Adelaide".to_string().into(),
+                sub: "SA".to_string().into(),
+                country: "Australia".to_string().into(),
+                street: "Cnr North Terrace and Frome Rd".to_string().into(),
+                postal_code: "5001".to_string().into(),
+                ..AffilStd::default()
+            })
+            .into(),
         },
         imp: None,
         medium: CitSubMedium::Paper,
@@ -226,7 +229,8 @@ fn parse_bioseq_desc_pub() {
             month: 3.into(),
             day: 28.into(),
             ..DateStd::default()
-        }).into(),
+        })
+        .into(),
         descr: None,
     })];
 
@@ -254,20 +258,16 @@ fn parse_bioseq_desc_pub() {
     let mut has_pub = false;
     for entry in bioseq.descr.unwrap().iter() {
         if let SeqDesc::Pub(desc) = entry {
-            let expected =
-                match desc.r#pub
-                    .first()
-                    .unwrap() {
+            let expected = match desc.r#pub.first().unwrap() {
                 Pub::Gen(_) => &expected2,
                 Pub::Sub(_) => &expected1,
-                _ => panic!("Encountered unexpected type")
+                _ => panic!("Encountered unexpected type"),
             };
             assert_eq!(desc, expected);
 
             if has_pub == false {
                 has_pub = true;
             }
-
         }
     }
 
@@ -286,7 +286,7 @@ fn parse_bioseq_desc_comment() {
             assert_eq!(*comment, expected);
             has_comment = true;
         }
-    };
+    }
     assert!(has_comment);
 }
 
@@ -312,7 +312,7 @@ fn parse_bioseq_desc_user() {
                 label: ObjectId::Str("Assembly".to_string()),
                 num: 1.into(),
                 data: UserData::Strs(vec!["GCF_030238925.1".to_string()]),
-            }
+            },
         ],
     };
     let expected2 = UserObject {
@@ -337,7 +337,9 @@ fn parse_bioseq_desc_user() {
             UserField {
                 label: ObjectId::Str("Annotation Pipeline".to_string()),
                 num: None,
-                data: UserData::Str("NCBI Prokaryotic Genome Annotation Pipeline (PGAP)".to_string()),
+                data: UserData::Str(
+                    "NCBI Prokaryotic Genome Annotation Pipeline (PGAP)".to_string(),
+                ),
             },
             UserField {
                 label: ObjectId::Str("Annotation Method".to_string()),
@@ -458,20 +460,16 @@ fn parse_bioseq_desc_user() {
             UserField {
                 label: ObjectId::Str("IdenticalTo".to_string()),
                 num: None,
-                data: UserData::Fields(vec![
-                    UserField {
-                        label: ObjectId::Id(0),
+                data: UserData::Fields(vec![UserField {
+                    label: ObjectId::Id(0),
+                    num: None,
+                    data: UserData::Fields(vec![UserField {
+                        label: ObjectId::Str("accession".to_string()),
                         num: None,
-                        data: UserData::Fields(vec![
-                            UserField {
-                                label: ObjectId::Str("accession".to_string()),
-                                num: None,
-                                data: UserData::Str("JARQWN010000024.1".to_string()),
-                            }
-                        ]),
-                    }
-                ]),
-            }
+                        data: UserData::Str("JARQWN010000024.1".to_string()),
+                    }]),
+                }]),
+            },
         ],
     };
     let expected4 = UserObject {
@@ -490,37 +488,37 @@ fn parse_bioseq_desc_user() {
             UserField {
                 label: ObjectId::Str("StructuredCommentPrefix".to_string()),
                 num: None,
-                data: UserData::Str("##Genome-Assembly-Data-START##".to_string())
+                data: UserData::Str("##Genome-Assembly-Data-START##".to_string()),
             },
             UserField {
                 label: ObjectId::Str("Assembly Method".to_string()),
                 num: None,
-                data: UserData::Str("SPAdes v. 1".to_string())
+                data: UserData::Str("SPAdes v. 1".to_string()),
             },
             UserField {
                 label: ObjectId::Str("Genome Representation".to_string()),
                 num: None,
-                data: UserData::Str("Full".to_string())
+                data: UserData::Str("Full".to_string()),
             },
             UserField {
                 label: ObjectId::Str("Expected Final Version".to_string()),
                 num: None,
-                data: UserData::Str("Yes".to_string())
+                data: UserData::Str("Yes".to_string()),
             },
             UserField {
                 label: ObjectId::Str("Genome Coverage".to_string()),
                 num: None,
-                data: UserData::Str("100x".to_string())
+                data: UserData::Str("100x".to_string()),
             },
             UserField {
                 label: ObjectId::Str("Sequencing Technology".to_string()),
                 num: None,
-                data: UserData::Str("Illumina HiSeq".to_string())
+                data: UserData::Str("Illumina HiSeq".to_string()),
             },
             UserField {
                 label: ObjectId::Str("StructuredCommentSuffix".to_string()),
                 num: None,
-                data: UserData::Str("##Genome-Assembly-Data-END##".to_string())
+                data: UserData::Str("##Genome-Assembly-Data-END##".to_string()),
             },
         ],
     };
@@ -532,7 +530,9 @@ fn parse_bioseq_desc_user() {
         if let SeqDesc::User(object) = entry {
             for exp in expected.iter() {
                 if object.r#type == exp.r#type {
-                    if object.r#type == ObjectId::Str("StructuredComment".to_string()) && object.data.first().unwrap() != exp.data.first().unwrap() {
+                    if object.r#type == ObjectId::Str("StructuredComment".to_string())
+                        && object.data.first().unwrap() != exp.data.first().unwrap()
+                    {
                         continue;
                     }
                     assert_eq!(object, exp);
@@ -542,7 +542,6 @@ fn parse_bioseq_desc_user() {
         }
     }
     assert!(has_user_object)
-
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -817,12 +817,11 @@ fn parse_bioseq_annot_feat_prot() {
 }
 
 #[test]
-#[ignore]
 fn parse_bioseq_annot_feat_pseudo() {
     let bioseq = get_bioseq(DATA1);
 
     // total number of occurrences of `SeqFeat.products`
-    let expected_occurrences: usize = 1;
+    let expected_occurrences: usize = 2;
 
     // track occurrence of object types
     if let Some(annot) = bioseq.annot {
@@ -833,8 +832,8 @@ fn parse_bioseq_annot_feat_pseudo() {
 
             // inspect parsed features
             for feat in ftable.iter() {
-                if let SeqFeatData::Gene(gene) = &feat.data {
-                    if gene.pseudo {
+                if let Some(pseudo) = feat.pseudo {
+                    if pseudo {
                         occurrences += 1;
                     }
                 }

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -815,3 +815,33 @@ fn parse_bioseq_annot_feat_prot() {
         }
     }
 }
+
+#[test]
+#[ignore]
+fn parse_bioseq_annot_feat_pseudo() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeat.products`
+    let expected_occurrences: usize = 1;
+
+    // track occurrence of object types
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for products
+            let mut occurrences: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if let SeqFeatData::Gene(gene) = &feat.data {
+                    if gene.pseudo {
+                        occurrences += 1;
+                    }
+                }
+            }
+
+            // assert parsed features
+            assert_eq!(expected_occurrences, occurrences);
+        }
+    }
+}

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -83,8 +83,7 @@ fn parse_bioseq_descr() {
     let bioseq = get_bioseq(DATA1);
 
     assert!(bioseq.descr.is_some());
-    // only BioSource should be parsed
-    assert_eq!(bioseq.descr.unwrap().len(), 1);
+    assert_eq!(bioseq.descr.unwrap().len(), 10);
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -545,6 +545,27 @@ fn parse_bioseq_desc_user() {
 }
 
 #[test]
+fn parse_bioseq_desc_create_date() {
+    let bioseq = get_bioseq(DATA1);
+
+    let date = Date::Date(DateStd {
+        year: 2023,
+        month: 6.into(),
+        day: 14.into(),
+        ..DateStd::default()
+    });
+
+    let mut has_create_date = false;
+    for entry in bioseq.descr.unwrap().iter() {
+        if let SeqDesc::CreateDate(inner) = entry {
+            assert_eq!(*inner, date);
+            has_create_date = true;
+        }
+    }
+    assert!(has_create_date);
+}
+
+#[test]
 #[ignore]
 fn parse_bioseq_inst() {
     let bioseq = get_bioseq(DATA1);

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -782,3 +782,36 @@ fn parse_bioseq_annot_feat_xrefs() {
         }
     }
 }
+
+#[test]
+fn parse_bioseq_annot_feat_prot() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeat.products`
+    let expected_occurrences: usize = 1;
+
+    // track occurrence of object types
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for products
+            let mut occurrences: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if let Some(xref) = &feat.xref {
+                    if let Some(xref) = xref.get(0) {
+                        if let Some(data) = &xref.data {
+                            if let SeqFeatData::Prot(_) = data {
+                                occurrences += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // assert parsed features
+            assert_eq!(expected_occurrences, occurrences);
+        }
+    }
+}

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -1,0 +1,95 @@
+use std::ops::Not;
+use ncbi::{DataType, get_local_xml, parse_xml};
+use ncbi::general::ObjectId;
+use ncbi::seq::BioSeq;
+use ncbi::seqloc::SeqId;
+use ncbi::seqset::{BioSeqSet, SeqEntry};
+
+const DATA1: &str = "tests/data/2519734237.xml";
+
+fn get_bioseq(path: &str) -> BioSeq {
+    let set = get_seq_set(path);
+    let entry = set.seq_set.get(0).unwrap();
+    match entry {
+        SeqEntry::Seq(data) => return data.clone(),
+        _ => panic!("Entry is not Bioseq")
+    }
+}
+
+fn get_seq_set(path: &str) -> BioSeqSet {
+    let data = get_local_xml(path);
+    let parsed = parse_xml(data.as_str()).unwrap();
+    if let DataType::BioSeqSet(set) = parsed {
+        return set
+    }
+    else {
+        panic!("No Bioseq set found")
+    }
+}
+
+#[test]
+fn has_seq_set() {
+    let data = get_seq_set(DATA1);
+    assert!(data.seq_set.is_empty().not());
+    assert_eq!(data.seq_set.len(), 1)
+}
+
+#[test]
+/// Variant is SeqEntry::seq
+fn parse_seq() {
+    let data = get_seq_set(DATA1);
+    let entry = data.seq_set.get(0).unwrap();
+    match entry {
+        SeqEntry::Seq(_) => assert!(true),
+        _ => assert!(false)
+    }
+}
+
+#[test]
+fn parse_bioseq_id() {
+    let bioseq = get_bioseq(DATA1);
+    assert!(bioseq.id.is_empty().not());
+    assert_eq!(bioseq.id.len(), 3);
+    for id in bioseq.id.iter() {
+        match id {
+            SeqId::General(tag) => {
+                assert_eq!(tag.db.as_str(), "WGS:NZ_JARQWN01");
+                if let ObjectId::Str(s) = &tag.tag {
+                    assert_eq!(s.as_str(), "NODE_24_length_86489_cov_60.972353")
+                }
+                else {
+                    assert!(false);
+                }
+            },
+            SeqId::Other(text) => {
+                assert_eq!(text.accession.as_ref().unwrap().as_str(), "NZ_JARQWN010000024");
+                assert_eq!(*text.version.as_ref().unwrap(), 1);
+                assert!(text.name.is_none());
+                assert!(text.release.is_none());
+            }
+            SeqId::Gi(gi) => assert_eq!(*gi, 2519734237),
+            _ => ()
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn parse_bioseq_descr() {
+    let bioseq = get_bioseq(DATA1);
+    assert!(bioseq.descr.is_some());
+}
+
+#[test]
+#[ignore]
+fn parse_bioseq_inst() {
+    let bioseq = get_bioseq(DATA1);
+    assert!(bioseq.inst.is_some());
+}
+
+#[test]
+#[ignore]
+fn parse_bioseq_annot() {
+    let bioseq = get_bioseq(DATA1);
+    assert!(bioseq.annot.is_some());
+}

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -755,3 +755,30 @@ fn parse_bioseq_annot_feat_comments() {
         }
     }
 }
+
+#[test]
+fn parse_bioseq_annot_feat_xrefs() {
+    let bioseq = get_bioseq(DATA1);
+
+    // total number of occurrences of `SeqFeat.products`
+    let expected_occurrences: usize = 1;
+
+    // track occurrence of object types
+    if let Some(annot) = bioseq.annot {
+        let annot = annot.get(0).unwrap();
+        if let SeqAnnotData::FTable(ftable) = &annot.data {
+            // counter for products
+            let mut occurrences: usize = 0;
+
+            // inspect parsed features
+            for feat in ftable.iter() {
+                if feat.xref.is_some() {
+                    occurrences += 1;
+                }
+            }
+
+            // assert parsed features
+            assert_eq!(expected_occurrences, occurrences);
+        }
+    }
+}

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -90,7 +90,7 @@ fn parse_bioseq_descr() {
     let bioseq = get_bioseq(DATA1);
 
     assert!(bioseq.descr.is_some());
-    assert_eq!(bioseq.descr.unwrap().len(), 11);
+    assert_eq!(bioseq.descr.unwrap().len(), 12);
 }
 
 #[test]
@@ -563,6 +563,27 @@ fn parse_bioseq_desc_create_date() {
         }
     }
     assert!(has_create_date);
+}
+
+#[test]
+fn parse_bioseq_desc_update_date() {
+    let bioseq = get_bioseq(DATA1);
+
+    let date = Date::Date(DateStd {
+        year: 2023,
+        month: 6.into(),
+        day: 14.into(),
+        ..DateStd::default()
+    });
+
+    let mut has_update_date = false;
+    for entry in bioseq.descr.unwrap().iter() {
+        if let SeqDesc::UpdateDate(inner) = entry {
+            assert_eq!(*inner, date);
+            has_update_date = true;
+        }
+    }
+    assert!(has_update_date);
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -1,7 +1,7 @@
 use std::ops::Not;
 use ncbi::{DataType, get_local_xml, parse_xml};
 use ncbi::general::{DbTag, ObjectId};
-use ncbi::seq::{BioSeq, SeqDesc};
+use ncbi::seq::{BioMol, BioSeq, Mol, MolInfo, MolTech, SeqDesc};
 use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, BioSourceOrigin, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
 use ncbi::seqloc::SeqId;
 use ncbi::seqset::{BioSeqSet, SeqEntry};
@@ -145,11 +145,36 @@ fn parse_bioseq_descr_source() {
         subtype,
         ..BioSource::default()
     };
+    let mut has_biosource = false;
     for entry in bioseq.descr.unwrap().iter() {
         if let SeqDesc::Source(source) = entry {
-            assert_eq!(*source, expected)
+            assert_eq!(*source, expected);
+            has_biosource = true;
         }
     }
+    assert!(has_biosource);
+}
+
+#[test]
+fn parse_bioseq_desc_molinfo() {
+    let bioseq = get_bioseq(DATA1);
+
+    let expected = MolInfo {
+        bio_mol: BioMol::Genomic,
+        tech: MolTech::WGS,
+        tech_exp: None,
+        completeness: Default::default(),
+        gb_mol_type: None,
+    };
+
+    let mut has_mol_info = false;
+    for entry in bioseq.descr.unwrap().iter() {
+        if let SeqDesc::MolInfo(mol_info) = entry {
+            assert_eq!(*mol_info, expected);
+            has_mol_info = true;
+        }
+    }
+    assert!(has_mol_info);
 }
 
 #[test]

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -1,11 +1,10 @@
 use std::ops::Not;
-use quick_xml::se::to_string;
 use ncbi::{DataType, get_local_xml, parse_xml};
 use ncbi::biblio::{Affil, AffilStd, AuthList, AuthListNames, Author, CitGen, CitSub, CitSubMedium};
 use ncbi::general::{Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject};
-use ncbi::r#pub::{Pub, PubEquiv};
-use ncbi::seq::{BioMol, BioSeq, Mol, MolInfo, MolTech, PubDesc, SeqDesc};
-use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, BioSourceOrigin, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
+use ncbi::r#pub::Pub;
+use ncbi::seq::{BioMol, BioSeq, MolInfo, MolTech, PubDesc, SeqDesc};
+use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
 use ncbi::seqloc::SeqId;
 use ncbi::seqset::{BioSeqSet, SeqEntry};
 

--- a/tests/bioseq.rs
+++ b/tests/bioseq.rs
@@ -5,12 +5,9 @@ use ncbi::general::{
     Date, DateStd, DbTag, NameStd, ObjectId, PersonId, UserData, UserField, UserObject,
 };
 use ncbi::r#pub::Pub;
-use ncbi::seq::{BioMol, BioSeq, MolInfo, MolTech, PubDesc, SeqDesc};
-use ncbi::seqfeat::{
-    BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice,
-    OrgRef, SubSource, SubSourceSubType,
-};
-use ncbi::seqloc::SeqId;
+use ncbi::seq::{BioMol, BioSeq, DeltaSeq, Mol, MolInfo, MolTech, PubDesc, Repr, SeqDesc, SeqExt, SeqInst, Strand};
+use ncbi::seqfeat::{BinomialOrgName, BioSource, BioSourceGenome, OrgMod, OrgModSubType, OrgName, OrgNameChoice, OrgRef, SubSource, SubSourceSubType};
+use ncbi::seqloc::{NaStrand, SeqId, SeqInterval, SeqLoc, TextseqId};
 use ncbi::seqset::{BioSeqSet, SeqEntry};
 use ncbi::{get_local_xml, parse_xml, DataType};
 use std::ops::Not;
@@ -587,10 +584,32 @@ fn parse_bioseq_desc_update_date() {
 }
 
 #[test]
-#[ignore]
 fn parse_bioseq_inst() {
     let bioseq = get_bioseq(DATA1);
     assert!(bioseq.inst.is_some());
+
+    let expected = SeqInst {
+        repr: Repr::Delta,
+        mol: Mol::DNA,
+        length: 86489.into(),
+        fuzz: None,
+        topology: Default::default(),
+        strand: Strand::NotSet,
+        seq_data: None,
+        ext: SeqExt::Delta(vec![DeltaSeq::Loc(SeqLoc::Int(SeqInterval {
+            from: 0,
+            to: 86488,
+            strand: NaStrand::Plus.into(),
+            id: SeqId::Genbank(TextseqId {
+                accession: "JARQWN010000024".to_string().into(),
+                version: 1.into(),
+                ..TextseqId::default()
+            }),
+            ..SeqInterval::default()
+        }))]).into(),
+        hist: None,
+    };
+    assert_eq!(bioseq.inst.unwrap(), expected);
 }
 
 #[test]


### PR DESCRIPTION
`BioSeq` can now be parsed directly from Entrez, or from XML saved on the filesystem. Most tags and variants have been implemented, however, when an unknown tag is encountered, the program either throws a warning or panics. Given the package is in alpha, the panics are meant so that issues are swiftly submitted upon usage.

# Changelist:
- Closes #10
- Closes #11 
- Closes #12 
- Closes #15 
- Closes #17
- Closes #18
- Closes #19