### PR TITLE
Fix: Indent in comment interpreted as code, not markdown

### DIFF
--- a/src/asn/biblio.rs
+++ b/src/asn/biblio.rs
@@ -286,7 +286,7 @@ pub enum CitSubMedium {
 /// Cite a direct data submission
 ///
 /// # Original Comment
-///     See "NCBI-Submit" for the form of a direct sequence submission
+/// See "NCBI-Submit" for the form of a direct sequence submission
 pub struct CitSub {
     /// not necessarily authors of the paper
     pub authors: AuthList,

--- a/src/asn/seqalign.rs
+++ b/src/asn/seqalign.rs
@@ -81,18 +81,17 @@ pub struct DenseDiag {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 /// The densest packing for sequence alignments only.
 ///
-///
 /// # Description
 ///
 /// A start of -1 indicates a gap for that sequence of length lens.
 ///
-///      id=100  AAGGCCTTTTAGAGATGATGATGATGATGA
-///      id=200  AAGGCCTTTTAG.......GATGATGATGA
-///      id=300  ....CCTTTTAGAGATGATGAT....ATGA
+///  id=100  AAGGCCTTTTAGAGATGATGATGATGATGA
+///  id=200  AAGGCCTTTTAG.......GATGATGATGA
+///  id=300  ....CCTTTTAGAGATGATGAT....ATGA
 ///
-///      dim = 3, numseg = 6, ids = { 100, 200, 300 }
-///      starts = { 0,0,-1, 4,4,0, 12,-1,8, 19,12,15, 22,15,-1, 26,19,18 }
-///      lens = { 4, 8, 7, 3, 4, 4 }
+///  dim = 3, numseg = 6, ids = { 100, 200, 300 }
+///  starts = { 0,0,-1, 4,4,0, 12,-1,8, 19,12,15, 22,15,-1, 26,19,18 }
+///  lens = { 4, 8, 7, 3, 4, 4 }
 ///
 pub struct DenseSeg {
     // TODO: default 2

--- a/src/asn/seqfeat.rs
+++ b/src/asn/seqfeat.rs
@@ -716,15 +716,15 @@ pub struct CdRegion {
     /// number of stop codons on above
     ///
     /// ### Original Comment:
-    ///     each code is 64 cells long, in the order where:
-    ///     `T=0, C=1, A=2, G=3, TTT=0, TTC=1, CTA=4, ...`
+    /// each code is 64 cells long, in the order where:
+    /// `T=0, C=1, A=2, G=3, TTT=0, TTC=1, CTA=4, ...`
     ///
-    ///     NOTE: this order does NOT correspond to a [`SeqData`] encoding.
-    ///     It is "natural" to codon usage instead. The value in each cell is
-    ///     the AA coded for start=AA coded only if first in peptide in start
-    ///     array, if codon is not a legitimate start codon, that cell will
-    ///     have the "gap" symbol for that alphabet. Otherwise it will have the
-    ///     AA encoded when that codon is used at the start.
+    /// NOTE: this order does NOT correspond to a [`SeqData`] encoding.
+    /// It is "natural" to codon usage instead. The value in each cell is
+    /// the AA coded for start=AA coded only if first in peptide in start
+    /// array, if codon is not a legitimate start codon, that cell will
+    /// have the "gap" symbol for that alphabet. Otherwise it will have the
+    /// AA encoded when that codon is used at the start.
     pub stops: Option<u64>,
 }
 
@@ -1330,10 +1330,10 @@ pub enum VariantAlleleState {
 /// for fields that were moved here, specifically `allele_frequency`, and
 /// `quality_codes`:
 ///
-///     The case of multiple alleles for a SNP would be described by
-///     parent-features of type `VariationSet.diff_alleles`, where the child
-///     features of type `VariationINst`, all at the same location, would
-///     describe individual alleles.
+/// The case of multiple alleles for a SNP would be described by
+/// parent-features of type `VariationSet.diff_alleles`, where the child
+/// features of type `VariationINst`, all at the same location, would
+/// describe individual alleles.
 ///
 pub struct VariantProperties {
     pub version: u64,
@@ -1789,15 +1789,15 @@ pub enum RnaRefType {
     rRNA,
 
     /// ### Original Comment:
-    ///     will become ncRNA, with RNAGen.class = snRNA
+    /// will become ncRNA, with RNAGen.class = snRNA
     snRNA,
 
     /// ### Original Comment:
-    ///     will become ncRNA, with RNAGen.class = snRNA
+    /// will become ncRNA, with RNAGen.class = snRNA
     scRNA,
 
     /// ### Original Comment:
-    ///     will become ncRNA, with RNAGen.class = snRNA
+    /// will become ncRNA, with RNAGen.class = snRNA
     snoRNA,
 
     /// non-coding RNA; subsumes `snRNA`, `scRNA` and `snoRNA`

--- a/src/asn/seqtable.rs
+++ b/src/asn/seqtable.rs
@@ -63,25 +63,25 @@ pub struct SeqTableColumnInfo {
     /// identification of column data in the objects described by the table
     pub field_id: Option<ColumnInfoFieldId>,
     /// # Original Comment:
-    ///     any column can be identified by ASN.1 text locator string
-    ///        -- with omitted object type.
-    ///        -- examples:
-    ///        --   "data.gene.locus" for SeqFeat.data.gene.locus
-    ///        --   "data.imp.key" for SeqFeat.data.imp.key
-    ///        --   "qual.qual"
-    ///        --    - SeqFeat.qual is SEQUENCE so several columns are allowed
-    ///        --      see also "Q.xxx" special value for shorter qual representation
-    ///        --   "ext.type.str"
-    ///        --   "ext.data.label.str"
-    ///        --   "ext.data.data.int"
-    ///        --      see also "E.xxx" special value for shorter ext representation
-    ///        -- special values start with capital letter:
-    ///        --   "E.xxx" - ext.data.label.str = xxx, ext.data.data = data
-    ///        --    - SeqFeat.ext.data is SEQUENCE so several columns are allowed
-    ///        --   "Q.xxx" - qual.qual = xxx, qual.val = data
-    ///        --    - SeqFeat.qual is SEQUENCE so several columns are allowed
-    ///        --   "D.xxx" - dbxref.id = xxx, dbxref.tag = data
-    ///        --    - SeqFeat.dbxref is SET so several columns are allowed
+    ///  any column can be identified by ASN.1 text locator string
+    ///  -- with omitted object type.
+    ///  -- examples:
+    ///  --   "data.gene.locus" for SeqFeat.data.gene.locus
+    ///  --   "data.imp.key" for SeqFeat.data.imp.key
+    ///  --   "qual.qual"
+    ///  --    - SeqFeat.qual is SEQUENCE so several columns are allowed
+    ///  --      see also "Q.xxx" special value for shorter qual representation
+    ///  --   "ext.type.str"
+    ///  --   "ext.data.label.str"
+    ///  --   "ext.data.data.int"
+    ///  --      see also "E.xxx" special value for shorter ext representation
+    ///  -- special values start with capital letter:
+    ///  --   "E.xxx" - ext.data.label.str = xxx, ext.data.data = data
+    ///  --    - SeqFeat.ext.data is SEQUENCE so several columns are allowed
+    ///  --   "Q.xxx" - qual.qual = xxx, qual.val = data
+    ///  --    - SeqFeat.qual is SEQUENCE so several columns are allowed
+    ///  --   "D.xxx" - dbxref.id = xxx, dbxref.tag = data
+    ///  --    - SeqFeat.dbxref is SET so several columns are allowed
     pub field_name: Option<String>,
 }
 
@@ -116,8 +116,8 @@ pub struct ScaledIntMultiData {
     /// Unsure on functionality.
     ///
     /// # Original comment:
-    ///     min/max scaled value
-    ///     should be set if scaled values may not fit in 32-bit signed integer
+    /// min/max scaled value
+    /// should be set if scaled values may not fit in 32-bit signed integer
     pub min: Option<i32>,
     pub max: Option<i32>,
 }
@@ -137,9 +137,9 @@ pub struct ScaledRealMultiData {
 /// Unsure on utility.
 ///
 /// # Original comment:
-///     Class for serializing bm::bvector<>     //[ likely a c++ construct ]
-///     see include/util/bitset/bm.h
-///     Since bvector<> serialization doesn't keep size we have to add it explicitly
+///  Class for serializing bm::bvector<>     //[ likely a c++ construct ]
+///  see include/util/bitset/bm.h
+///  Since bvector<> serialization doesn't keep size we have to add it explicitly
 pub struct BVectorData {
     pub size: u64,
     pub data: Vec<u8>,
@@ -185,8 +185,8 @@ pub enum SeqTableMultiData {
     RealScaled(ScaledRealMultiData),
 
     /// # Original comment:
-    ///     a set of bit, represented as a serialized bvector
-    ///     see include/util/bitset/bm.h
+    /// a set of bit, represented as a serialized bvector,
+    /// see include/util/bitset/bm.h
     BitVector(BVectorData),
 
     #[serde(rename = "int1")]
@@ -230,8 +230,8 @@ pub enum SeqTableSparseIndex {
     IndexesDelta(Vec<u64>),
 
     /// # Original comment:
-    ///     Bitset of rows with values, as serialized bvector<>,
-    ///     see include/util/bitset/bm.h
+    /// Bitset of rows with values, as serialized bvector<>,
+    /// see include/util/bitset/bm.h
     BitSetBvector(BVectorData),
 }
 
@@ -261,14 +261,14 @@ pub struct SeqTable {
     ///
     /// Original comment:
     ///
-    ///     ... equal to Seq-feat.data variant index
+    /// ... equal to Seq-feat.data variant index
     pub feat_type: usize,
 
     /// subtype of features in this table, ...
     ///
     /// # Original comment:
     ///
-    ///     ... defined in header SeqFeatData.hpp
+    /// ... defined in header SeqFeatData.hpp
     pub feat_subtype: Option<usize>,
 
     /// number of rows


### PR DESCRIPTION
The multiple indentations were interpreted as code.
"cargo test" failed because of it. Fixed now.
From my superficial look at it my changes should not harm the autogenerated documentation too much. Please adjust as you see fit.